### PR TITLE
Requester can confirm or deny help offer

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,23 @@ if other activity response status 500 with message:
 Auth headers are required. Offer :id in endpoint.
 
 ```
-{ offer: offer.id, message: 'Your offer is pending' }
-{ offer: offer.id, message: 'Your offer has been accepted' }
-{ offer: offer.id, message: 'Your offer has been declined' }
+{
+  offer:  id: 4,
+  message: "here is the message",
+  helper_id: 2,
+  request_id: 3,
+  status: "accepted",
+  message: 'Your offer has been accepted'
+ }
+{
+  offer: id: 4,
+  message: "here is the message",
+  helper_id: 2,
+  request_id: 3,
+  status: "accepted",
+  message: 'Your offer has been declined'
+  }
+
+  { offer: <offer items>,
+  message: 'Your offer is pending' }
 ```

--- a/README.md
+++ b/README.md
@@ -80,13 +80,42 @@ If ok, response is 200:
 ```
 { message: 'Your offer has been sent!' }
 ```
+
 Some other errors can happen as well, unauthorized 401 if headers are missing:
+
 ```
 {"errors"=>["You need to sign in or sign up before continuing."]}
 ```
+
 Or 422 if you try a forbidden action or have bad params:
+
 ```
 { message: 'You cannot offer help on your own request!' }
 { message: 'Helper_id is already registered with this request' }
 { message: "Couldn't find Request with 'id'=blob" }
+```
+
+#### PUT /offers
+
+Auth headers are required. Param :activity that can be declined or accepted as string.
+
+```
+{ offer: offer.id, message: 'offer is accepted' }
+{ offer: offer.id, message: 'offer is declined' }
+```
+
+if other activity response status 500 with message:
+
+```
+{ error_message: 'The activty is not valid' }
+```
+
+#### GET /offers/:id
+
+Auth headers are required. Offer :id in endpoint.
+
+```
+{ offer: offer.id, message: 'Your offer is pending' }
+{ offer: offer.id, message: 'Your offer has been accepted' }
+{ offer: offer.id, message: 'Your offer has been declined' }
 ```

--- a/app/controllers/api/offers_controller.rb
+++ b/app/controllers/api/offers_controller.rb
@@ -24,4 +24,4 @@ class Api::OffersController < ApplicationController
 
     { helper: current_user, request: target_request, message: params[:message] }
   end
-end
+d

--- a/app/controllers/api/offers_controller.rb
+++ b/app/controllers/api/offers_controller.rb
@@ -14,6 +14,18 @@ class Api::OffersController < ApplicationController
     render json: { message: e.message }, status: 422
   end
 
+  def update
+    offer = Offer.find(params[:id])
+    
+    if offer.update(status: params[:activity])
+      render json: ''
+    else
+
+    end
+
+
+  end 
+
   def show
     offer = current_user.offers.find(params[:id])
 

--- a/app/controllers/api/offers_controller.rb
+++ b/app/controllers/api/offers_controller.rb
@@ -8,7 +8,7 @@ class Api::OffersController < ApplicationController
     if offer.persisted?
       render json: { message: 'Your offer has been sent!' }
     else
-      render json: { message: offer.errors.full_messages.join(". ") }, status: 422
+      render json: { message: offer.errors.full_messages.join('. ') }, status: 422
     end
   rescue StandardError => e
     render json: { message: e.message }, status: 422
@@ -16,15 +16,14 @@ class Api::OffersController < ApplicationController
 
   def update
     offer = Offer.find(params[:id])
-    
     if offer.update(status: params[:activity])
-      render json: ''
+      offer.request.helper_id = offer.helper_id
+      render json: { offer: offer.id, message: 'offer is accepted' }
     else
-
+      binding.pry
+      render json: { message: offer.errors.full_messages.join('. ') }, status: 422
     end
-
-
-  end 
+  end
 
   def show
     offer = current_user.offers.find(params[:id])
@@ -38,10 +37,10 @@ class Api::OffersController < ApplicationController
       when 'declined'
         message = 'Your offer has been declined'
       end
-      
-      render json: {offer: offer, status_message: message} 
+
+      render json: { offer: offer, status_message: message }
     else
-      render json: {error_message: 'Offer cannot be found'}
+      render json: { error_message: 'Offer cannot be found' }
     end
   end
 

--- a/app/controllers/api/offers_controller.rb
+++ b/app/controllers/api/offers_controller.rb
@@ -18,26 +18,23 @@ class Api::OffersController < ApplicationController
     offer = Offer.find(params[:id])
     if offer.update(status: params[:activity])
       offer.request.helper_id = offer.helper_id
-      render json: { offer: offer.id, message: 'offer is accepted' }
+      render json: { offer: offer.id, message: "offer is #{offer.status}" }
     else
-      binding.pry
       render json: { message: offer.errors.full_messages.join('. ') }, status: 422
     end
   end
 
   def show
     offer = current_user.offers.find(params[:id])
-
     if offer
       case offer.status
       when 'pending'
         message = 'Your offer is pending'
-      when 'approved'
+      when 'accepted'
         message = 'Your offer has been accepted'
       when 'declined'
         message = 'Your offer has been declined'
       end
-
       render json: { offer: offer, status_message: message }
     else
       render json: { error_message: 'Offer cannot be found' }

--- a/app/controllers/api/offers_controller.rb
+++ b/app/controllers/api/offers_controller.rb
@@ -14,6 +14,25 @@ class Api::OffersController < ApplicationController
     render json: { message: e.message }, status: 422
   end
 
+  def show
+    offer = current_user.offers.find(params[:id])
+
+    if offer
+      case offer.status
+      when 'pending'
+        message = 'Your offer is pending'
+      when 'approved'
+        message = 'Your offer has been accepted'
+      when 'declined'
+        message = 'Your offer has been declined'
+      end
+      
+      render json: {offer: offer, status_message: message} 
+    else
+      render json: {error_message: 'Offer cannot be found'}
+    end
+  end
+
   private
 
   def check_and_lump_parameters
@@ -24,4 +43,4 @@ class Api::OffersController < ApplicationController
 
     { helper: current_user, request: target_request, message: params[:message] }
   end
-d
+end

--- a/app/controllers/api/offers_controller.rb
+++ b/app/controllers/api/offers_controller.rb
@@ -23,10 +23,11 @@ class Api::OffersController < ApplicationController
     when 'accepted'
       offer.update(status: params[:activity])
       request.update(helper: offer.helper)
-      render json: { offer: offer.id, message: "offer is #{offer.status}" }
+      request.update(status: 'active')
+      render json: { offer: offer.id, message: "You #{offer.status} help from #{offer.helper.uid}" }
     when 'declined'
       offer.update(status: params[:activity])
-      render json: { offer: offer.id, message: "offer is #{offer.status}" }
+      render json: { offer: offer.id, message: "You #{offer.status} help from #{offer.helper.uid}" }
     else
       render_offer_error('The activty is not valid')
     end

--- a/app/controllers/api/offers_controller.rb
+++ b/app/controllers/api/offers_controller.rb
@@ -2,9 +2,10 @@
 
 class Api::OffersController < ApplicationController
   before_action :authenticate_user!
+  rescue_from ActiveRecord::RecordNotFound, with: :render_offer_error
 
   def create
-    offer = Offer.create(check_and_convert_parameters)
+    offer = current_user.offers.create(offer_parameters)
     if offer.persisted?
       render json: { message: 'Your offer has been sent!' }
     else
@@ -16,39 +17,47 @@ class Api::OffersController < ApplicationController
 
   def update
     offer = Offer.find(params[:id])
-    if offer.update(status: params[:activity])
-      offer.request.helper_id = offer.helper_id
+    request = Request.find(offer.request.id)
+
+    case params[:activity]
+    when 'accepted'
+      offer.update(status: params[:activity])
+      request.update(helper: offer.helper)
+      render json: { offer: offer.id, message: "offer is #{offer.status}" }
+    when 'declined'
+      offer.update(status: params[:activity])
       render json: { offer: offer.id, message: "offer is #{offer.status}" }
     else
-      render json: { message: offer.errors.full_messages.join('. ') }, status: 422
+      render_offer_error('The activty is not valid')
     end
+  rescue StandardError => e
+    render_offer_error(e)
   end
 
   def show
     offer = current_user.offers.find(params[:id])
-    if offer
-      case offer.status
-      when 'pending'
-        message = 'Your offer is pending'
-      when 'accepted'
-        message = 'Your offer has been accepted'
-      when 'declined'
-        message = 'Your offer has been declined'
-      end
-      render json: { offer: offer, status_message: message }
-    else
-      render json: { error_message: 'Offer cannot be found' }
-    end
+    render json: { offer: offer, status_message: set_status_message(offer.status) }
   end
 
   private
 
-  def check_and_convert_parameters
-    target_request = Request.find(params[:request_id])
-    if target_request.requester == current_user
-      raise StandardError, 'You cannot offer help on your own request!'
+  def set_status_message(activity)
+    case activity
+    when 'pending'
+      'Your offer is pending'
+    when 'accepted'
+      'Your offer has been accepted'
+    when 'declined'
+      'Your offer has been declined'
     end
+  end
 
-    { helper: current_user, request: target_request, message: params[:message] }
+  def render_offer_error(error)
+    error_message = error.try(:message) || error
+    render json: { error_message: error_message }, status: 500
+  end
+
+  def offer_parameters
+    params.permit(:message, :request_id)
   end
 end

--- a/app/controllers/api/requests_controller.rb
+++ b/app/controllers/api/requests_controller.rb
@@ -19,12 +19,12 @@ class Api::RequestsController < ApplicationController
     render json: requests, each_serializer: Request::IndexSerializer
   end
 
+  private
+
   def update_karma
     Api::KarmaPointsController.update_karma(request_params, current_user)
   end
-
-  private
-
+  
   def karma?
     unless (current_user.karma_points - request_params[:reward].to_i).positive? || (current_user.karma_points - request_params[:reward].to_i == 0)
       render json: { message: 'You dont have enough karma points' }, status: 422

--- a/app/controllers/api/requests_controller.rb
+++ b/app/controllers/api/requests_controller.rb
@@ -19,6 +19,7 @@ class Api::RequestsController < ApplicationController
     render json: requests, each_serializer: Request::IndexSerializer
   end
 
+
   private
 
   def update_karma

--- a/app/controllers/api/requests_controller.rb
+++ b/app/controllers/api/requests_controller.rb
@@ -19,7 +19,6 @@ class Api::RequestsController < ApplicationController
     render json: requests, each_serializer: Request::IndexSerializer
   end
 
-
   private
 
   def update_karma

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
 class Offer < ApplicationRecord
   belongs_to :request
   belongs_to :helper, class_name: 'User'
   validates_uniqueness_of :helper_id, scope: :request_id, message: 'is already registered with this request'
+  enum status: %i[pending approved declined finished]
 end

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -4,5 +4,5 @@ class Offer < ApplicationRecord
   belongs_to :request
   belongs_to :helper, class_name: 'User'
   validates_uniqueness_of :helper_id, scope: :request_id, message: 'is already registered with this request'
-  enum status: %i[pending approved declined finished]
+  enum status: %i[pending approved declined]
 end

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -1,8 +1,18 @@
 # frozen_string_literal: true
 
 class Offer < ApplicationRecord
+  before_validation :validate_offer, on: [:create]
+  validates_presence_of :status
   belongs_to :request
   belongs_to :helper, class_name: 'User'
   validates_uniqueness_of :helper_id, scope: :request_id, message: 'is already registered with this request'
   enum status: %i[pending accepted declined]
+
+  private
+
+  def validate_offer
+    if helper_id.present? && helper_id === request.requester.id
+      raise StandardError, 'You cannot offer help on your own request!'
+    end
+  end
 end

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -4,5 +4,5 @@ class Offer < ApplicationRecord
   belongs_to :request
   belongs_to :helper, class_name: 'User'
   validates_uniqueness_of :helper_id, scope: :request_id, message: 'is already registered with this request'
-  enum status: %i[pending approved declined]
+  enum status: %i[pending accepted declined]
 end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -3,5 +3,6 @@
 class Request < ApplicationRecord
   validates_presence_of :title, :description, :reward
   belongs_to :requester, class_name: 'User'
+  belongs_to :helper, required: false, class_name: 'User'
   has_many :offers
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,5 @@ class User < ActiveRecord::Base
 
   has_many :requests, foreign_key: 'requester_id', class_name: 'Request'
   has_many :offers, foreign_key: 'helper_id', class_name: 'Offer'
+  has_many :quests, foreign_key: 'helper_id', class_name: 'Request'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@
 Rails.application.routes.draw do
   mount_devise_token_auth_for 'User', at: 'api/auth'
   namespace :api do
-    resources :offers, only: %i[:create show]
+    resources :offers, only: %i[:create show update]
     resources :karma_points, only: [:index], constraints: { format: 'json' }
     resources :requests, only: %i[create index], constraints: { format: 'json' }
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@
 Rails.application.routes.draw do
   mount_devise_token_auth_for 'User', at: 'api/auth'
   namespace :api do
-    resources :offers, only: [:create]
+    resources :offers, only: %i[:create show]
     resources :karma_points, only: [:index], constraints: { format: 'json' }
     resources :requests, only: %i[create index], constraints: { format: 'json' }
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@
 Rails.application.routes.draw do
   mount_devise_token_auth_for 'User', at: 'api/auth'
   namespace :api do
-    resources :offers, only: %i[:create show update]
+    resources :offers, only: %i[create show update]
     resources :karma_points, only: [:index], constraints: { format: 'json' }
     resources :requests, only: %i[create index], constraints: { format: 'json' }
   end

--- a/db/migrate/20200617173352_add_status_to_offer.rb
+++ b/db/migrate/20200617173352_add_status_to_offer.rb
@@ -1,0 +1,5 @@
+class AddStatusToOffer < ActiveRecord::Migration[6.0]
+  def change
+    add_column :offers, :status, :integer, default: 0
+  end
+end

--- a/db/migrate/20200617183349_add_helper_to_requests.rb
+++ b/db/migrate/20200617183349_add_helper_to_requests.rb
@@ -1,0 +1,5 @@
+class AddHelperToRequests < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :requests, :helper, foreign_key: { to_table: :users }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_17_173352) do
+ActiveRecord::Schema.define(version: 2020_06_17_183349) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,8 @@ ActiveRecord::Schema.define(version: 2020_06_17_173352) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.integer "reward"
+    t.bigint "helper_id"
+    t.index ["helper_id"], name: "index_requests_on_helper_id"
     t.index ["requester_id"], name: "index_requests_on_requester_id"
   end
 
@@ -67,5 +69,6 @@ ActiveRecord::Schema.define(version: 2020_06_17_173352) do
   end
 
   add_foreign_key "offers", "users", column: "helper_id"
+  add_foreign_key "requests", "users", column: "helper_id"
   add_foreign_key "requests", "users", column: "requester_id"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_16_170538) do
+ActiveRecord::Schema.define(version: 2020_06_17_173352) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2020_06_16_170538) do
     t.bigint "request_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "status", default: 0
     t.index ["helper_id"], name: "index_offers_on_helper_id"
     t.index ["request_id", "helper_id"], name: "index_offers_on_request_id_and_helper_id", unique: true
     t.index ["request_id"], name: "index_offers_on_request_id"

--- a/spec/factories/offers.rb
+++ b/spec/factories/offers.rb
@@ -1,7 +1,6 @@
-FactoryBot.define do
-  factory :offer do
-    message { "I want to help" }
-    association :helper, factory: :user, email: "helper@mail.com"
-    association :request
-  end
+    message { iI want  to help' }
+  association :hel    r, factory: :user
+ association :request
+      end
 end
+sta

--- a/spec/factories/offers.rb
+++ b/spec/factories/offers.rb
@@ -1,6 +1,8 @@
-    message { iI want  to help' }
-  association :hel    r, factory: :user
- association :request
-      end
+FactoryBot.define do
+  factory :offer do
+    message { 'iI want  to help' }
+    association :helper, factory: :user
+    association :request
+    status { 'pending' }
+  end
 end
-sta

--- a/spec/factories/offers.rb
+++ b/spec/factories/offers.rb
@@ -1,7 +1,8 @@
 FactoryBot.define do
   factory :offer do
     message { "I want to help" }
-    association :helper, factory: :user, email: "helper@mail.com"
+    association :helper, factory: :user
     association :request
+    status { 'pending' }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,7 +2,9 @@
 
 FactoryBot.define do
   factory :user do
-    email { 'MyString@mail.com' }
+    sequence :email do |n|
+      "person#{n}@example.com"
+    end
     password { 'MyString123' }
     karma_points { 100 }
   end

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -1,11 +1,13 @@
+# frozen_string_literal: true
+
 RSpec.describe Offer, type: :model do
   describe 'database table' do
     it { is_expected.to have_db_column :message }
     it { is_expected.to have_db_column :request_id }
     it { is_expected.to have_db_column :helper_id }
+    it { is_expected.to have_db_column :status }
   end
 
-    it { is_expected.to have_db_column :status }
   describe 'relations' do
     it { is_expected.to belong_to :helper }
     it { is_expected.to belong_to :request }

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Offer, type: :model do
     it { is_expected.to have_db_column :message }
   end
 
+    it { is_expected.to have_db_column :status }
   describe 'relations' do
     it { is_expected.to belong_to :helper }
     it { is_expected.to belong_to :request }

--- a/spec/requests/api/offers/create_spec.rb
+++ b/spec/requests/api/offers/create_spec.rb
@@ -2,9 +2,11 @@ RSpec.describe 'POST /offers, user can offer to help' do
   let(:requester) { create(:user, email: 'requester@mail.com') }
   let(:req_creds) { requester.create_new_auth_token }
   let(:req_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(req_creds) }
+
   let(:helper) { create(:user) }
-  let(:credentials) { helper.create_new_auth_token }
-  let(:helper_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(credentials) }
+  let(:helper_credentials) { helper.create_new_auth_token }
+  let(:helper_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(helper_credentials) }
+  
   let(:request) { create(:request, requester: requester) }
 
   describe 'with authentication and correct params' do

--- a/spec/requests/api/offers/show_spec.rb
+++ b/spec/requests/api/offers/show_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe 'GET /api/offers/:id', type: :request do
+  let(:requester) { create(:user) }
+  let(:request) { create(:request, requester_id: requester.id) }
+
+  let(:helper) { create(:user) }
+  let(:helper_credentials) { helper.create_new_auth_token }
+  let(:helper_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(helper_credentials) }
+
+  let(:offer) { 
+    create(:offer, message: 'I can help you', helper_id: helper.id, request_id: request.id) 
+  }
+
+  describe 'with valid params and headers' do
+    before do
+      get `/api/offers/#{offer.id}`,
+           headers: helper_headers,
+           params: { request_id: request.id }
+    end
+
+    it 'has 200 response' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'responds offer message' do
+      expect(response_json['offer']['message']).to eq 'I can help you'
+    end
+
+    it 'responds offer status' do
+      expect(response_json['offer']['status']).to eq 'pending'
+    end
+  end
+
+  #   describe 'reQuest is declined' do
+  #     before do
+  #       get "/api/offers/#{request.id}", params: { activity: 'decline' }, headers: headers
+  #     end
+
+  #     it 'has 200 response' do
+  #       expect(response).to have_http_status 200
+  #     end
+
+  #     it 'responds with a message' do
+  #       expect(response_json['message']).to eq 'Sorry, your offer has been declined!'
+  #     end
+  #   end
+  # end
+end

--- a/spec/requests/api/offers/show_spec.rb
+++ b/spec/requests/api/offers/show_spec.rb
@@ -8,15 +8,15 @@ RSpec.describe 'GET /api/offers/:id', type: :request do
   let(:helper_credentials) { helper.create_new_auth_token }
   let(:helper_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(helper_credentials) }
 
-  let(:offer) { 
-    create(:offer, message: 'I can help you', helper_id: helper.id, request_id: request.id) 
-  }
+  
 
-  describe 'with valid params and headers' do
+  describe 'with valid params and headers for pending request' do
+    let(:offer) { 
+      create(:offer, message: 'I can help you', helper_id: helper.id, request_id: request.id) 
+    }
     before do
-      get `/api/offers/#{offer.id}`,
-           headers: helper_headers,
-           params: { request_id: request.id }
+      get "/api/offers/#{offer.id}",
+           headers: helper_headers
     end
 
     it 'has 200 response' do
@@ -30,20 +30,61 @@ RSpec.describe 'GET /api/offers/:id', type: :request do
     it 'responds offer status' do
       expect(response_json['offer']['status']).to eq 'pending'
     end
+
+    it 'responds with offer status message' do
+      expect(response_json['status_message']).to eq 'Your offer is pending'
+    end
   end
 
-  #   describe 'reQuest is declined' do
-  #     before do
-  #       get "/api/offers/#{request.id}", params: { activity: 'decline' }, headers: headers
-  #     end
+  describe 'with valid params and headers for approved request' do
+    let(:offer) { 
+      create(:offer, status: 'approved', message: 'I can help you', helper_id: helper.id, request_id: request.id) 
+    }
+    before do
+      get "/api/offers/#{offer.id}",
+           headers: helper_headers
+    end
 
-  #     it 'has 200 response' do
-  #       expect(response).to have_http_status 200
-  #     end
+    it 'has 200 response' do
+      expect(response).to have_http_status 200
+    end
 
-  #     it 'responds with a message' do
-  #       expect(response_json['message']).to eq 'Sorry, your offer has been declined!'
-  #     end
-  #   end
-  # end
+    it 'responds offer message' do
+      expect(response_json['offer']['message']).to eq 'I can help you'
+    end
+
+    it 'responds offer status' do
+      expect(response_json['offer']['status']).to eq 'approved'
+    end
+
+    it 'responds with offer status message' do
+      expect(response_json['status_message']).to eq 'Your offer has been accepted'
+    end
+  end
+
+  describe 'with valid params and headers for declined request' do
+    let(:offer) { 
+      create(:offer, status: 'declined', message: 'I can help you', helper_id: helper.id, request_id: request.id) 
+    }
+    before do
+      get "/api/offers/#{offer.id}",
+           headers: helper_headers
+    end
+
+    it 'has 200 response' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'responds offer message' do
+      expect(response_json['offer']['message']).to eq 'I can help you'
+    end
+
+    it 'responds offer status' do
+      expect(response_json['offer']['status']).to eq 'declined'
+    end
+
+    it 'responds with offer status message' do
+      expect(response_json['status_message']).to eq 'Your offer has been declined'
+    end
+  end
 end

--- a/spec/requests/api/offers/show_spec.rb
+++ b/spec/requests/api/offers/show_spec.rb
@@ -9,38 +9,12 @@ RSpec.describe 'GET /api/offers/:id', type: :request do
   let(:helper_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(helper_credentials) }
 
   describe 'with valid params and headers for pending request' do
-    let(:offer) { 
-      create(:offer, message: 'I can help you', helper_id: helper.id, request_id: request.id) 
-    }
+    let(:offer) do
+      create(:offer, message: 'I can help you', helper_id: helper.id, request_id: request.id)
+    end
     before do
       get "/api/offers/#{offer.id}",
-           headers: helper_headers
-    end
-
-    it 'has 200 response' do
-      expect(response).to have_http_status 200
-    end
-
-    it 'responds offer message' do
-      expect(response_json['offer']['message']).to eq 'accept offer'
-    end
-
-    it 'responds offer status' do
-      expect(response_json['offer']['status']).to eq 'pending'
-    end
-
-    it 'responds with offer status message' do
-      expect(response_json['status_message']).to eq 'Your offer is pending'
-    end
-  end
-
-  describe 'with valid params and headers for approved request' do
-    let(:offer) { 
-      create(:offer, status: 'approved', message: 'I can help you', helper_id: helper.id, request_id: request.id) 
-    }
-    before do
-      get "/api/offers/#{offer.id}",
-           headers: helper_headers
+          headers: helper_headers
     end
 
     it 'has 200 response' do
@@ -52,7 +26,33 @@ RSpec.describe 'GET /api/offers/:id', type: :request do
     end
 
     it 'responds offer status' do
-      expect(response_json['offer']['status']).to eq 'approved'
+      expect(response_json['offer']['status']).to eq 'pending'
+    end
+
+    it 'responds with offer status message' do
+      expect(response_json['status_message']).to eq 'Your offer is pending'
+    end
+  end
+
+  describe 'with valid params and headers for accepted request' do
+    let(:offer) do
+      create(:offer, status: 'accepted', message: 'I can help you', helper_id: helper.id, request_id: request.id)
+    end
+    before do
+      get "/api/offers/#{offer.id}",
+          headers: helper_headers
+    end
+
+    it 'has 200 response' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'responds offer message' do
+      expect(response_json['offer']['message']).to eq 'I can help you'
+    end
+
+    it 'responds offer status' do
+      expect(response_json['offer']['status']).to eq 'accepted'
     end
 
     it 'responds with offer status message' do
@@ -61,12 +61,12 @@ RSpec.describe 'GET /api/offers/:id', type: :request do
   end
 
   describe 'with valid params and headers for declined request' do
-    let(:offer) { 
-      create(:offer, status: 'declined', message: 'I can help you', helper_id: helper.id, request_id: request.id) 
-    }
+    let(:offer) do
+      create(:offer, status: 'declined', message: 'I can help you', helper_id: helper.id, request_id: request.id)
+    end
     before do
       get "/api/offers/#{offer.id}",
-           headers: helper_headers
+          headers: helper_headers
     end
 
     it 'has 200 response' do

--- a/spec/requests/api/offers/show_spec.rb
+++ b/spec/requests/api/offers/show_spec.rb
@@ -1,0 +1,88 @@
+RSpec.describe 'GET /api/offers/:id', type: :request do
+  let(:requester) { create(:user) }
+  let(:request) { create(:request, requester_id: requester.id) }
+
+  let(:helper) { create(:user) }
+  let(:helper_credentials) { helper.create_new_auth_token }
+  let(:helper_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(helper_credentials) }
+
+  
+
+  describe 'with valid params and headers for pending request' do
+    let(:offer) { 
+      create(:offer, message: 'I can help you', helper_id: helper.id, request_id: request.id) 
+    }
+    before do
+      get "/api/offers/#{offer.id}",
+           headers: helper_headers
+    end
+
+    it 'has 200 response' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'responds offer message' do
+      expect(response_json['offer']['message']).to eq 'I can help you'
+    end
+
+    it 'responds offer status' do
+      expect(response_json['offer']['status']).to eq 'pending'
+    end
+
+    it 'responds with offer status message' do
+      expect(response_json['status_message']).to eq 'Your offer is pending'
+    end
+  end
+
+  describe 'with valid params and headers for approved request' do
+    let(:offer) { 
+      create(:offer, status: 'approved', message: 'I can help you', helper_id: helper.id, request_id: request.id) 
+    }
+    before do
+      get "/api/offers/#{offer.id}",
+           headers: helper_headers
+    end
+
+    it 'has 200 response' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'responds offer message' do
+      expect(response_json['offer']['message']).to eq 'I can help you'
+    end
+
+    it 'responds offer status' do
+      expect(response_json['offer']['status']).to eq 'approved'
+    end
+
+    it 'responds with offer status message' do
+      expect(response_json['status_message']).to eq 'Your offer has been accepted'
+    end
+  end
+
+  describe 'with valid params and headers for declined request' do
+    let(:offer) { 
+      create(:offer, status: 'declined', message: 'I can help you', helper_id: helper.id, request_id: request.id) 
+    }
+    before do
+      get "/api/offers/#{offer.id}",
+           headers: helper_headers
+    end
+
+    it 'has 200 response' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'responds offer message' do
+      expect(response_json['offer']['message']).to eq 'I can help you'
+    end
+
+    it 'responds offer status' do
+      expect(response_json['offer']['status']).to eq 'declined'
+    end
+
+    it 'responds with offer status message' do
+      expect(response_json['status_message']).to eq 'Your offer has been declined'
+    end
+  end
+end

--- a/spec/requests/api/offers/show_spec.rb
+++ b/spec/requests/api/offers/show_spec.rb
@@ -8,8 +8,6 @@ RSpec.describe 'GET /api/offers/:id', type: :request do
   let(:helper_credentials) { helper.create_new_auth_token }
   let(:helper_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(helper_credentials) }
 
-  
-
   describe 'with valid params and headers for pending request' do
     let(:offer) { 
       create(:offer, message: 'I can help you', helper_id: helper.id, request_id: request.id) 
@@ -24,7 +22,7 @@ RSpec.describe 'GET /api/offers/:id', type: :request do
     end
 
     it 'responds offer message' do
-      expect(response_json['offer']['message']).to eq 'I can help you'
+      expect(response_json['offer']['message']).to eq 'accept offer'
     end
 
     it 'responds offer status' do

--- a/spec/requests/api/offers/update_spec.rb
+++ b/spec/requests/api/offers/update_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe 'PUT /api/offers/:id', type: :request do
+  let(:requester) { create(:user) }
+  let(:requester_credentials) {requester.create_new_auth_token}
+  let(:requester_headers) {{ HTTP_ACCEPT: 'application/json' }.merge!(requester_credentials)}
+  let(:request) { create(:request, requester_id: requester.id) }
+
+  let(:helper) { create(:user) }
+  let(:offer) { create(:offer, status: 'pending', request_id: request.id, helper_id: helper.id)}
+
+  describe 'requester accepts offer' do
+    before do
+      put "/api/offers/#{offer.id}",
+           headers: requester_headers,
+           params: { activity: 'approved'}
+    end
+
+    it 'has 200 response' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'responds offer message' do
+      expect(response_json['message']).to eq 'Helper is set'
+    end
+  end
+end

--- a/spec/requests/api/offers/update_spec.rb
+++ b/spec/requests/api/offers/update_spec.rb
@@ -9,20 +9,20 @@ RSpec.describe 'PUT /api/offers/:id', type: :request do
   let(:helper) { create(:user) }
   let(:offer) { create(:offer, status: 'pending', request_id: request.id, helper_id: helper.id) }
 
-  describe 'requester successfully' do 
+  describe 'requester successfully' do
     describe 'accepts offer' do
       before do
         put "/api/offers/#{offer.id}",
             headers: requester_headers,
             params: { activity: 'accepted' }
       end
-  
+
       it 'has 200 response' do
         expect(response).to have_http_status 200
       end
-  
+
       it 'responds offer message' do
-        expect(response_json['message']).to eq 'offer is accepted'
+        expect(response_json['message']).to eq "You accepted help from #{helper.email}"
       end
     end
 
@@ -32,17 +32,17 @@ RSpec.describe 'PUT /api/offers/:id', type: :request do
             headers: requester_headers,
             params: { activity: 'declined' }
       end
-  
+
       it 'responds offer message' do
-        expect(response_json['message']).to eq 'offer is declined'
+        expect(response_json['message']).to eq "You declined help from #{helper.email}"
       end
     end
   end
 
-  describe 'unsuccessfully when' do 
+  describe 'unsuccessfully when' do
     describe 'offer cant be found' do
       before do
-        put "/api/offers/1000",
+        put '/api/offers/1000',
             headers: requester_headers,
             params: { activity: 'declined' }
       end
@@ -50,7 +50,7 @@ RSpec.describe 'PUT /api/offers/:id', type: :request do
       it 'has 500 response' do
         expect(response).to have_http_status 500
       end
-  
+
       it 'responds error message' do
         expect(response_json['error_message']).to eq "Couldn't find Offer with 'id'=1000"
       end
@@ -65,9 +65,9 @@ RSpec.describe 'PUT /api/offers/:id', type: :request do
       it 'has 422 response' do
         expect(response).to have_http_status 500
       end
-  
+
       it 'responds error message' do
-        expect(response_json['error_message']).to eq "The activty is not valid"
+        expect(response_json['error_message']).to eq 'The activty is not valid'
       end
     end
 
@@ -79,7 +79,7 @@ RSpec.describe 'PUT /api/offers/:id', type: :request do
       it 'has 401 response' do
         expect(response).to have_http_status 401
       end
-  
+
       it 'responds error message' do
         expect(response_json['errors'].first).to eq 'You need to sign in or sign up before continuing.'
       end
@@ -90,15 +90,14 @@ RSpec.describe 'PUT /api/offers/:id', type: :request do
         put "/api/offers/#{offer.id}",
             headers: requester_headers,
             params: { activity: 'invalid status' }
-
       end
 
       it 'has 500 response' do
         expect(response).to have_http_status 500
       end
-  
+
       it 'responds error message' do
-        expect(response_json['error_message']).to eq "The activty is not valid"
+        expect(response_json['error_message']).to eq 'The activty is not valid'
       end
     end
   end

--- a/spec/requests/api/offers/update_spec.rb
+++ b/spec/requests/api/offers/update_spec.rb
@@ -4,35 +4,102 @@ RSpec.describe 'PUT /api/offers/:id', type: :request do
   let(:requester) { create(:user) }
   let(:requester_credentials) { requester.create_new_auth_token }
   let(:requester_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(requester_credentials) }
+
   let(:request) { create(:request, requester_id: requester.id) }
   let(:helper) { create(:user) }
   let(:offer) { create(:offer, status: 'pending', request_id: request.id, helper_id: helper.id) }
 
-  describe 'requester accepts offer' do
-    before do
-      put "/api/offers/#{offer.id}",
-          headers: requester_headers,
-          params: { activity: 'accepted' }
+  describe 'requester successfully' do 
+    describe 'accepts offer' do
+      before do
+        put "/api/offers/#{offer.id}",
+            headers: requester_headers,
+            params: { activity: 'accepted' }
+      end
+  
+      it 'has 200 response' do
+        expect(response).to have_http_status 200
+      end
+  
+      it 'responds offer message' do
+        expect(response_json['message']).to eq 'offer is accepted'
+      end
     end
 
-    it 'has 200 response' do
-      expect(response).to have_http_status 200
-    end
-
-    it 'responds offer message' do
-      expect(response_json['message']).to eq 'offer is accepted'
+    describe 'declines offer' do
+      before do
+        put "/api/offers/#{offer.id}",
+            headers: requester_headers,
+            params: { activity: 'declined' }
+      end
+  
+      it 'responds offer message' do
+        expect(response_json['message']).to eq 'offer is declined'
+      end
     end
   end
 
-  describe 'requester declines offer' do
-    before do
-      put "/api/offers/#{offer.id}",
-          headers: requester_headers,
-          params: { activity: 'declined' }
+  describe 'unsuccessfully when' do 
+    describe 'offer cant be found' do
+      before do
+        put "/api/offers/1000",
+            headers: requester_headers,
+            params: { activity: 'declined' }
+      end
+
+      it 'has 500 response' do
+        expect(response).to have_http_status 500
+      end
+  
+      it 'responds error message' do
+        expect(response_json['error_message']).to eq "Couldn't find Offer with 'id'=1000"
+      end
     end
 
-    it 'responds offer message' do
-      expect(response_json['message']).to eq 'offer is declined'
+    describe 'no activity params is sent' do
+      before do
+        put "/api/offers/#{offer.id}",
+            headers: requester_headers
+      end
+
+      it 'has 422 response' do
+        expect(response).to have_http_status 500
+      end
+  
+      it 'responds error message' do
+        expect(response_json['error_message']).to eq "The activty is not valid"
+      end
+    end
+
+    describe 'user is not logged in' do
+      before do
+        put "/api/offers/#{offer.id}"
+      end
+
+      it 'has 401 response' do
+        expect(response).to have_http_status 401
+      end
+  
+      it 'responds error message' do
+        expect(response_json['errors'].first).to eq 'You need to sign in or sign up before continuing.'
+      end
+    end
+
+    describe 'does not send in valid status' do
+      before do
+        put "/api/offers/#{offer.id}",
+            headers: requester_headers,
+            params: { activity: 'invalid status' }
+
+      end
+
+      it 'has 500 response' do
+        expect(response).to have_http_status 500
+      end
+  
+      it 'responds error message' do
+        expect(response_json['error_message']).to eq "The activty is not valid"
+      end
     end
   end
 end

--- a/spec/requests/api/offers/update_spec.rb
+++ b/spec/requests/api/offers/update_spec.rb
@@ -1,17 +1,18 @@
+# frozen_string_literal: true
+
 RSpec.describe 'PUT /api/offers/:id', type: :request do
   let(:requester) { create(:user) }
-  let(:requester_credentials) {requester.create_new_auth_token}
-  let(:requester_headers) {{ HTTP_ACCEPT: 'application/json' }.merge!(requester_credentials)}
+  let(:requester_credentials) { requester.create_new_auth_token }
+  let(:requester_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(requester_credentials) }
   let(:request) { create(:request, requester_id: requester.id) }
-
   let(:helper) { create(:user) }
-  let(:offer) { create(:offer, status: 'pending', request_id: request.id, helper_id: helper.id)}
+  let(:offer) { create(:offer, status: 'pending', request_id: request.id, helper_id: helper.id) }
 
   describe 'requester accepts offer' do
     before do
       put "/api/offers/#{offer.id}",
-           headers: requester_headers,
-           params: { activity: 'approved'}
+          headers: requester_headers,
+          params: { activity: 'accepted' }
     end
 
     it 'has 200 response' do
@@ -19,7 +20,19 @@ RSpec.describe 'PUT /api/offers/:id', type: :request do
     end
 
     it 'responds offer message' do
-      expect(response_json['message']).to eq 'Helper is set'
+      expect(response_json['message']).to eq 'offer is accepted'
+    end
+  end
+
+  describe 'requester declines offer' do
+    before do
+      put "/api/offers/#{offer.id}",
+          headers: requester_headers,
+          params: { activity: 'declined' }
+    end
+
+    it 'responds offer message' do
+      expect(response_json['message']).to eq 'offer is declined'
     end
   end
 end


### PR DESCRIPTION
### Requester can confirm or deny a help offer
[PT link](https://www.pivotaltracker.com/story/show/173333045)
```
As a requester,
In order to only let people whom I deem worthy help me,
I would like to be able to accept or dismiss help offerings
```

- Added offers#update action with 2 paths depending on :activity "decline" or "accept"
- Added routes for update and show action
- Added offers#show action that provides :message
- Added logic that sets helper on request
- Added associations request, as quest/user, as helper
- Added status enum to offer model

#### PUT /offers

Auth headers are required. Param :activity that can be declined or accepted as string.

```
{ offer: offer.id, message: 'offer is accepted' }
{ offer: offer.id, message: 'offer is declined' }
```

if other activity response status 500 with message:

```
{ error_message: 'The activty is not valid' }
```

#### GET /offers/:id

Auth headers are required. Offer :id in endpoint.

```
{ offer: offer.id, message: 'Your offer is pending' }
{ offer: offer.id, message: 'Your offer has been accepted' }
{ offer: offer.id, message: 'Your offer has been declined' }
```