### PR TITLE
Requester can see specific reQuest

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,12 @@ The format is:
     "description": "This is what I need help with", 
     "reward": 100, 
     "offers": [
-      "person1@example.com", 
-      "person2@example.com"
+      {
+        "email": "person1@example.com"
+      },
+      {
+        "email": "person2@example.com"
+      }
     ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ The format is:
 }
 ```
 
+Targeting a request that you're not the owner of, renders 422 and error message:
+```
+{ "message": "This is not your reQuest" }
+```
+
 #### POST my_request/requests
 
 To create a new request you need to include authentication headers.
@@ -63,10 +68,10 @@ If auth is missing, devise will throw the following with 401:
 {"errors": ["You need to sign in or sign up before continuing."]}
 ```
 
-If a param, e.g. description is missing, you will get 422:
+If a param, e.g. description and reward is missing, you will get 422:
 
 ```
-{ message: 'Description can't be blank' }
+{ message: 'Description can't be blank and Reward can't be blank' }
 ```
 
 If a non-valid category is supplied you will get 422:
@@ -102,7 +107,7 @@ Headers as parameter needed for getting the request list of a specific user
 ```
 
 ```
-{"message"=>"There are no requests to show"}
+{"message"=>"There are no reQuests to show"}
 ```
 
 ### /karma_points

--- a/README.md
+++ b/README.md
@@ -26,14 +26,32 @@ The format is:
   ]
 }
 ```
+
 ### my_request/
+
+#### GET my_request/requests/:id
+
+```
+{
+  "request": {
+    "id": 1597, 
+    "title": "I need help with this", 
+    "description": "This is what I need help with", 
+    "reward": 100, 
+    "offers": [
+      "person1@example.com", 
+      "person2@example.com"
+    ]
+  }
+}
+```
+
 #### POST my_request/requests
 
 To create a new request you need to include authentication headers.
 You also need to provide :title=String and :description=String, and may provide category.
 Valid categories are "other", "education", "home", "it", "sport", "vehicles". Other is default if none is provided.
 The response will be a 200 with a message and the id of the created resource.
-
 
 ```
 { message: 'Your reQuest was successfully created!', id: <resource_id>, karma_points: <users karma_points> }
@@ -42,7 +60,7 @@ The response will be a 200 with a message and the id of the created resource.
 If auth is missing, devise will throw the following with 401:
 
 ```
-{"errors"=>["You need to sign in or sign up before continuing."]}
+{"errors": ["You need to sign in or sign up before continuing."]}
 ```
 
 If a param, e.g. description is missing, you will get 422:
@@ -92,7 +110,7 @@ If ok, response is 200:
 Some other errors can happen as well, unauthorized 401 if headers are missing:
 
 ```
-{"errors"=>["You need to sign in or sign up before continuing."]}
+{"errors": ["You need to sign in or sign up before continuing."]}
 ```
 
 Or 422 if you try a forbidden action or have bad params:

--- a/app/controllers/api/my_request/requests_controller.rb
+++ b/app/controllers/api/my_request/requests_controller.rb
@@ -5,6 +5,9 @@ class Api::MyRequest::RequestsController < ApplicationController
   before_action :karma?, only: [:create]
   rescue_from ArgumentError, with: :render_error_message
 
+  def show
+  end
+
   def create
     request = current_user.requests.create(create_params)
     if request.persisted?

--- a/app/controllers/api/my_request/requests_controller.rb
+++ b/app/controllers/api/my_request/requests_controller.rb
@@ -6,6 +6,8 @@ class Api::MyRequest::RequestsController < ApplicationController
   rescue_from ArgumentError, with: :render_error_message
 
   def show
+    request = Request.find(show_params[:id])
+    render json: request, serializer: MyRequest::Request::ShowSerializer
   end
 
   def create
@@ -55,6 +57,10 @@ class Api::MyRequest::RequestsController < ApplicationController
     end
 
     render json: { message: error_message }, status: 422
+  end
+
+  def show_params
+    params.permit(:id)
   end
 
   def create_params

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -10,7 +10,7 @@ class Request < ApplicationRecord
   validate :validate_pending_status, on: :update
 
   def is_requested_by?(user)
-    raise(StandardError, 'Request not reachable') && (return false) unless requester == user
+    raise(StandardError, 'This is not your reQuest') && (return false) unless requester == user
     true
   end
 

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -10,7 +10,7 @@ class Request < ApplicationRecord
   validate :validate_pending_status, on: :update
 
   def is_requested_by?(user)
-    raise(StandardError, 'This is not your reQuest') && (return false) unless requester == user
+    raise(StandardError, 'This is not your reQuest') unless requester == user
     true
   end
 

--- a/app/serializers/my_request/request/show_serializer.rb
+++ b/app/serializers/my_request/request/show_serializer.rb
@@ -1,0 +1,13 @@
+class MyRequest::Request::ShowSerializer < ActiveModel::Serializer
+  attributes :id, :title, :description, :reward, :offers
+
+  def offers
+    offer_uids = []
+    object.offers.each do |offer|
+      helper = User.find(offer.helper_id)
+      offer_uids << helper.uid
+    end
+    
+    return offer_uids
+  end
+end

--- a/app/serializers/my_request/request/show_serializer.rb
+++ b/app/serializers/my_request/request/show_serializer.rb
@@ -2,12 +2,12 @@ class MyRequest::Request::ShowSerializer < ActiveModel::Serializer
   attributes :id, :title, :description, :reward, :offers
 
   def offers
-    offer_uids = []
+    offers_response = []
     object.offers.each do |offer|
       helper = User.find(offer.helper_id)
-      offer_uids << helper.uid
+      offers_response << { email: helper.email } 
     end
     
-    return offer_uids
+    return offers_response
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
     resources :karma_points, only: [:index], constraints: { format: 'json' }
     resources :requests, only: %i[index], constraints: { format: 'json' }
     namespace :my_request do
-      resources :requests, only: [:create, :update], constraints: { format: 'json' }
+      resources :requests, only: %i[show create update], constraints: { format: 'json' }
     end
   end
 end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Request, type: :model do
       subject { create(:request, requester: user, status: 'pending') }
       it 'returns false if user is NOT requester' do
         expect { subject.is_requested_by?(another_user) }
-          .to raise_error StandardError, 'Request not reachable'
+          .to raise_error StandardError, 'This is not your reQuest'
       end
     end
   end

--- a/spec/requests/api/my_request/requests/create_spec.rb
+++ b/spec/requests/api/my_request/requests/create_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe 'POST /api/my_request/requests', type: :request do
       end
 
       it 'responds with an error message' do
-        expect(response_json['message']).to eq "Description, Reward can't be blank"
+        expect(response_json['message']).to eq "Description can't be blank and Reward can't be blank"
       end
     end
 

--- a/spec/requests/api/my_request/requests/index_spec.rb
+++ b/spec/requests/api/my_request/requests/index_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'GET /api/my_requests/requests, users can see their list of reque
     end
   end
 
-  describe 'when there are no requests' do
+  describe 'when there are no reQuests' do
     before do
       get '/api/my_request/requests', headers: headers_2
     end
@@ -76,7 +76,7 @@ RSpec.describe 'GET /api/my_requests/requests, users can see their list of reque
     end
 
     it 'responds error message' do
-      expect(response_json['message']).to eq 'There are no requests to show'
+      expect(response_json['message']).to eq 'There are no reQuests to show'
     end
   end
 end

--- a/spec/requests/api/my_request/requests/show_spec.rb
+++ b/spec/requests/api/my_request/requests/show_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe 'GET /api/my_request/requests/:id', type: :request do
       expect(response_json['request']['offers'].length).to eq 2
     end
 
-    it "responds with the offering helper's uid" do
-      expect(response_json['request']['offers'][0]).to eq user_1.uid
+    it "responds with the offering helper's email" do
+      expect(response_json['request']['offers'][0]['email']).to eq user_1.email
     end
   end
 

--- a/spec/requests/api/my_request/requests/show_spec.rb
+++ b/spec/requests/api/my_request/requests/show_spec.rb
@@ -55,6 +55,10 @@ RSpec.describe 'GET /api/my_request/requests/:id', type: :request do
     it 'has 401 status' do
       expect(response).to have_http_status 401
     end
+
+    it 'responds with error message' do
+      expect(response_json['errors'][0]).to eq 'You need to sign in or sign up before continuing.'
+    end
   end
 
   describe "targeting someone else's reQuest" do
@@ -65,6 +69,10 @@ RSpec.describe 'GET /api/my_request/requests/:id', type: :request do
 
     it 'has 401 status' do
       expect(response).to have_http_status 401
+    end
+    
+    it 'responds with error message' do
+      expect(response_json['message']).to eq "This is not your reQuest"
     end
   end 
 end

--- a/spec/requests/api/my_request/requests/show_spec.rb
+++ b/spec/requests/api/my_request/requests/show_spec.rb
@@ -1,20 +1,20 @@
 # frozen_string_literal: true
 
 RSpec.describe 'GET /api/my_request/requests/:id', type: :request do
-  let!(:requester) { create(:user, email: 'requester@mail.com')}
-  let!(:credentials) { requester.create_new_auth_token }
-  let!(:headers) { { HTTP_ACCEPT: 'application/json' }.merge!(credentials) }
-  let!(:myrequest) { create(:request, requester: requester) }
-  let!(:user1) { create(:user) }
-  let!(:user2) { create(:user) }
-  let!(:notmyrequest) { create(:request, requester: user1) }
+  let(:requester) { create(:user, email: 'requester@mail.com')}
+  let(:credentials) { requester.create_new_auth_token }
+  let(:headers) { { HTTP_ACCEPT: 'application/json' }.merge!(credentials) }
+  let(:my_request) { create(:request, requester: requester) }
+  let(:user_1) { create(:user) }
+  let(:user_2) { create(:user) }
+  let(:not_my_request) { create(:request, requester: user_1) }
 
-  let!(:offer1) { create(:offer, helper: user1, request: myrequest) }
-  let!(:offer2) { create(:offer, helper: user2, request: myrequest) }
+  let!(:offer_1) { create(:offer, helper: user_1, request: my_request) }
+  let!(:offer_2) { create(:offer, helper: user_2, request: my_request) }
 
   describe 'with valid credentials and params' do
     before do
-      get "/api/my_request/requests/#{myrequest.id}",
+      get "/api/my_request/requests/#{my_request.id}",
         headers: headers
     end
 
@@ -23,19 +23,19 @@ RSpec.describe 'GET /api/my_request/requests/:id', type: :request do
     end
 
     it 'responds with id' do
-      expect(response_json['request']['id']).to eq myrequest.id
+      expect(response_json['request']['id']).to eq my_request.id
     end
 
     it 'responds with title' do
-      expect(response_json['request']['title']).to eq myrequest.title
+      expect(response_json['request']['title']).to eq my_request.title
     end
 
     it 'responds with description' do
-      expect(response_json['request']['description']).to eq myrequest.description
+      expect(response_json['request']['description']).to eq my_request.description
     end
 
     it 'responds with reward' do
-      expect(response_json['request']['reward']).to eq myrequest.reward
+      expect(response_json['request']['reward']).to eq my_request.reward
     end
 
     it 'responds with all offers associated with the reQuest' do
@@ -43,13 +43,13 @@ RSpec.describe 'GET /api/my_request/requests/:id', type: :request do
     end
 
     it "responds with the offering helper's uid" do
-      expect(response_json['request']['offers'][0]).to eq user1.uid
+      expect(response_json['request']['offers'][0]).to eq user_1.uid
     end
   end
 
   describe 'without valid credentials' do
     before do
-      get "/api/my_request/requests/#{myrequest.id}"
+      get "/api/my_request/requests/#{my_request.id}"
     end
 
     it 'has 401 status' do
@@ -63,7 +63,7 @@ RSpec.describe 'GET /api/my_request/requests/:id', type: :request do
 
   describe "targeting someone else's reQuest" do
     before do
-      get "/api/my_request/requests/#{notmyrequest.id}",
+      get "/api/my_request/requests/#{not_my_request.id}",
         headers: headers
     end
 

--- a/spec/requests/api/my_request/requests/show_spec.rb
+++ b/spec/requests/api/my_request/requests/show_spec.rb
@@ -23,19 +23,27 @@ RSpec.describe 'GET /api/my_request/requests/:id', type: :request do
     end
 
     it 'responds with id' do
-      expect(response_json['id']).to eq myrequest.id
+      expect(response_json['request']['id']).to eq myrequest.id
     end
 
     it 'responds with title' do
-      expect(response_json['title']).to eq myrequest.title
+      expect(response_json['request']['title']).to eq myrequest.title
     end
 
     it 'responds with description' do
-      expect(response_json['description']).to eq myrequest.description
+      expect(response_json['request']['description']).to eq myrequest.description
+    end
+
+    it 'responds with reward' do
+      expect(response_json['request']['reward']).to eq myrequest.reward
     end
 
     it 'responds with all offers associated with the reQuest' do
-      expect(response_json['offers'].length).to eq 2
+      expect(response_json['request']['offers'].length).to eq 2
+    end
+
+    it "responds with the offering helper's uid" do
+      expect(response_json['request']['offers'][0]).to eq user1.uid
     end
   end
 

--- a/spec/requests/api/my_request/requests/show_spec.rb
+++ b/spec/requests/api/my_request/requests/show_spec.rb
@@ -72,7 +72,8 @@ RSpec.describe 'GET /api/my_request/requests/:id', type: :request do
     end
     
     it 'responds with error message' do
-      expect(response_json['message']).to eq "This is not your reQuest"
+      expect(response_json['message'])
+      .to eq 'Something went wrong: This is not your reQuest '
     end
   end 
 end

--- a/spec/requests/api/my_request/requests/show_spec.rb
+++ b/spec/requests/api/my_request/requests/show_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+RSpec.describe 'GET /api/my_request/requests/:id', type: :request do
+  let!(:requester) { create(:user, email: 'requester@mail.com')}
+  let!(:credentials) { requester.create_new_auth_token }
+  let!(:headers) { { HTTP_ACCEPT: 'application/json' }.merge!(credentials) }
+  let!(:myrequest) { create(:request, requester: requester) }
+  let!(:user1) { create(:user) }
+  let!(:user2) { create(:user) }
+  let!(:notmyrequest) { create(:request, requester: user1) }
+
+  let!(:offer1) { create(:offer, helper: user1, request: myrequest) }
+  let!(:offer2) { create(:offer, helper: user2, request: myrequest) }
+
+  describe 'with valid credentials and params' do
+    before do
+      get "/api/my_request/requests/#{myrequest.id}",
+        headers: headers
+    end
+
+    it 'has 200 response' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'responds with id' do
+      expect(response_json['id']).to eq myrequest.id
+    end
+
+    it 'responds with title' do
+      expect(response_json['title']).to eq myrequest.title
+    end
+
+    it 'responds with description' do
+      expect(response_json['description']).to eq myrequest.description
+    end
+
+    it 'responds with all offers associated with the reQuest' do
+      expect(response_json['offers'].length).to eq 2
+    end
+  end
+
+  describe 'without valid credentials' do
+    before do
+      get "/api/my_request/requests/#{myrequest.id}"
+    end
+
+    it 'has 401 status' do
+      expect(response).to have_http_status 401
+    end
+  end
+
+  describe "targeting someone else's reQuest" do
+    before do
+      get "/api/my_request/requests/#{notmyrequest.id}",
+        headers: headers
+    end
+
+    it 'has 401 status' do
+      expect(response).to have_http_status 401
+    end
+  end 
+end

--- a/spec/requests/api/my_request/requests/show_spec.rb
+++ b/spec/requests/api/my_request/requests/show_spec.rb
@@ -67,13 +67,12 @@ RSpec.describe 'GET /api/my_request/requests/:id', type: :request do
         headers: headers
     end
 
-    it 'has 401 status' do
-      expect(response).to have_http_status 401
+    it 'has 422 status' do
+      expect(response).to have_http_status 422
     end
     
     it 'responds with error message' do
-      expect(response_json['message'])
-      .to eq 'Something went wrong: This is not your reQuest '
+      expect(response_json['message']).to eq 'This is not your reQuest'
     end
   end 
 end

--- a/spec/requests/api/my_request/requests/user_can_mark_a_request_complete_spec.rb
+++ b/spec/requests/api/my_request/requests/user_can_mark_a_request_complete_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'Api::MyRequest::Requests :update', type: :request do
 
     it 'responds with the completed confirmation' do
       expect(response_json['message'])
-      .to eq 'Request completed!'
+      .to eq 'reQuest completed!'
     end
   end
 
@@ -49,12 +49,11 @@ RSpec.describe 'Api::MyRequest::Requests :update', type: :request do
     end
 
     it 'responds with the completed confirmation' do
-      expect(response_json['message'])
-      .to eq 'Something went wrong: This is not your reQuest '
+      expect(response_json['message']).to eq 'This is not your reQuest'
     end
   end
 
-  describe "User can't mark pending request completed" do
+  describe "User can't mark pending reQuest completed" do
     before do
       put "/api/my_request/requests/#{request_2.id}",
           headers: headers,
@@ -72,7 +71,7 @@ RSpec.describe 'Api::MyRequest::Requests :update', type: :request do
 
     it 'responds with the completed confirmation' do
       expect(response_json['message'])
-        .to eq 'Something went wrong: Status cannot be set to completed when it is pending '
+        .to eq 'Validation failed: Status cannot be set to completed when it is pending'
     end
   end
 end

--- a/spec/requests/api/my_request/requests/user_can_mark_a_request_complete_spec.rb
+++ b/spec/requests/api/my_request/requests/user_can_mark_a_request_complete_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'Api::MyRequest::Requests :update', type: :request do
 
     it 'responds with the completed confirmation' do
       expect(response_json['message'])
-      .to eq 'Something went wrong: Request not reachable '
+      .to eq 'Something went wrong: This is not your reQuest '
     end
   end
 

--- a/spec/requests/api/offers/update_spec.rb
+++ b/spec/requests/api/offers/update_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe 'PUT /api/offers/:id', type: :request do
             headers: requester_headers
       end
 
-      it 'has 422 response' do
+      it 'has 500 response' do
         expect(response).to have_http_status 500
       end
 


### PR DESCRIPTION
[PT link](https://www.pivotaltracker.com/story/show/173393096)

# Feature

* Requester can make a GET request for a specific reQuest
  -- contains all information necessary for the specific reQuest view on front end
  -- { request: { id, title, description, reward, offers: { [{ email: helper.email }, { email: helper2.email }] } }


* There's also a few refactorings and relevant corrections in this PR, hence the amount of files changed...