### PR TITLE
Points are (rewarded) transferred when a quest is completed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ If auth is missing, devise will throw the following with 401:
 {"errors": ["You need to sign in or sign up before continuing."]}
 ```
 
-If a param, e.g. description and reward is missing, you will get 422:
+If a param, e.g. description and reward is missing, or reward is negative or not a number, you will get 422:
 
 ```
 { message: 'Description can't be blank and Reward can't be blank' }

--- a/app/controllers/api/my_request/requests_controller.rb
+++ b/app/controllers/api/my_request/requests_controller.rb
@@ -34,6 +34,7 @@ class Api::MyRequest::RequestsController < ApplicationController
   def update
     request = Request.find(update_params[:id])
     request.is_requested_by?(current_user) && request.send("#{update_params[:activity]}!".to_sym)
+    request.helper.reward_karma_points(request.reward)
     render json: { message: 'reQuest completed!' }
   end
 

--- a/app/controllers/api/my_request/requests_controller.rb
+++ b/app/controllers/api/my_request/requests_controller.rb
@@ -34,7 +34,6 @@ class Api::MyRequest::RequestsController < ApplicationController
   def update
     request = Request.find(update_params[:id])
     request.is_requested_by?(current_user) && request.send("#{update_params[:activity]}!".to_sym)
-    request.reward_helper
     render json: { message: 'reQuest completed!' }
   end
 

--- a/app/controllers/api/my_request/requests_controller.rb
+++ b/app/controllers/api/my_request/requests_controller.rb
@@ -13,7 +13,7 @@ class Api::MyRequest::RequestsController < ApplicationController
     else
       render json: requests, each_serializer: MyRequest::Request::IndexSerializer
     end
- end
+  end
 
   def show
     request = Request.find(show_params[:id])
@@ -34,7 +34,7 @@ class Api::MyRequest::RequestsController < ApplicationController
   def update
     request = Request.find(update_params[:id])
     request.is_requested_by?(current_user) && request.send("#{update_params[:activity]}!".to_sym)
-    request.helper.reward_karma_points(request.reward)
+    request.reward_helper
     render json: { message: 'reQuest completed!' }
   end
 

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -20,6 +20,10 @@ class Request < ApplicationRecord
     update(status: 'active', helper: helper)
   end
 
+  def reward_helper
+    helper.reward_karma_points(reward)
+  end
+
   private
 
   def validate_pending_status

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -8,6 +8,7 @@ class Request < ApplicationRecord
   enum status: { pending: 0, active: 1, started: 2, completed: 3 }
   enum category: { other: 0, education: 1, home: 2, it: 3, sport: 4, vehicles: 5 }
   validate :validate_pending_status, on: :update
+  validates_numericality_of :reward, greater_than_or_equal_to: 0
 
   def is_requested_by?(user)
     raise(StandardError, 'This is not your reQuest') unless requester == user

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -9,6 +9,7 @@ class Request < ApplicationRecord
   enum category: { other: 0, education: 1, home: 2, it: 3, sport: 4, vehicles: 5 }
   validate :validate_pending_status, on: :update
   validates_numericality_of :reward, greater_than_or_equal_to: 0
+  after_update :reward_helper
 
   def is_requested_by?(user)
     raise(StandardError, 'This is not your reQuest') unless requester == user
@@ -21,7 +22,7 @@ class Request < ApplicationRecord
   end
 
   def reward_helper
-    helper.reward_karma_points(reward)
+    helper.reward_karma_points(reward) if completed?
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,4 +9,8 @@ class User < ActiveRecord::Base
   has_many :requests, foreign_key: 'requester_id', class_name: 'Request'
   has_many :offers, foreign_key: 'helper_id', class_name: 'Offer'
   has_many :quests, foreign_key: 'helper_id', class_name: 'Request'
+
+  def reward_karma_points(points)
+    self.update_attribute(:karma_points, self.karma_points + points)
+  end
 end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe Request, type: :model do
     it { is_expected.to validate_presence_of :status }
     it { is_expected.to validate_presence_of :category }
 
+    it { is_expected.to validate_numericality_of(:reward).is_greater_than_or_equal_to(0) }
+
     describe 'prevents requester from updating request status to completed while pending' do
       subject { create(:request, requester: user, status: 'pending') }
       before do
@@ -53,7 +55,5 @@ RSpec.describe Request, type: :model do
           .to raise_error StandardError, 'This is not your reQuest'
       end
     end
-
-    it { is_expected.to validate_numericality_of(:reward).is_greater_than_or_equal_to(0) }
   end
 end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -53,5 +53,7 @@ RSpec.describe Request, type: :model do
           .to raise_error StandardError, 'This is not your reQuest'
       end
     end
+
+    it { is_expected.to validate_numericality_of(:reward).is_greater_than_or_equal_to(0) }
   end
 end

--- a/spec/requests/api/my_request/requests/create_spec.rb
+++ b/spec/requests/api/my_request/requests/create_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe 'POST /api/my_request/requests', type: :request do
       end
 
       it 'responds with an error message' do
-        expect(response_json['message']).to eq "Description can't be blank and Reward can't be blank"
+        expect(response_json['message']).to eq "Description can't be blank, Reward can't be blank, and Reward is not a number"
       end
     end
 
@@ -122,7 +122,7 @@ RSpec.describe 'POST /api/my_request/requests', type: :request do
       end
 
       it 'responds with an error message' do
-        expect(response_json['message']).to eq "Reward can't be blank"
+        expect(response_json['message']).to eq "Reward can't be blank and Reward is not a number"
       end
     end
 

--- a/spec/requests/api/my_request/requests/user_can_mark_a_request_complete_spec.rb
+++ b/spec/requests/api/my_request/requests/user_can_mark_a_request_complete_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe 'Api::MyRequest::Requests :update', type: :request do
           headers: headers,
           params: { activity: 'completed' }
       request.reload
-      user2.reload
     end
 
     it 'has 200 response' do
@@ -34,6 +33,7 @@ RSpec.describe 'Api::MyRequest::Requests :update', type: :request do
     end
 
     it 'rewards the helper with the karma points from the request' do
+      user2.reload
       expect(user2.karma_points).to eq @points_before + request.reward
     end
   end

--- a/spec/requests/api/my_request/requests/user_can_mark_a_request_complete_spec.rb
+++ b/spec/requests/api/my_request/requests/user_can_mark_a_request_complete_spec.rb
@@ -7,15 +7,17 @@ RSpec.describe 'Api::MyRequest::Requests :update', type: :request do
   let(:headers) { { HTTP_ACCEPT: 'application/json' }.merge!(credentials) }
   let(:user2_credentials) { user2.create_new_auth_token }
   let(:user2_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(user2_credentials) }
-  let(:request) { create(:request, requester: user, status: 'active') }
+  let(:request) { create(:request, requester: user, status: 'active', helper: user2) }
   let(:request_2) { create(:request, requester: user) }
 
   describe 'User can mark request as completed ' do
     before do
+      @points_before = user2.karma_points
       put "/api/my_request/requests/#{request.id}",
           headers: headers,
           params: { activity: 'completed' }
       request.reload
+      user2.reload
     end
 
     it 'has 200 response' do
@@ -29,6 +31,10 @@ RSpec.describe 'Api::MyRequest::Requests :update', type: :request do
     it 'responds with the completed confirmation' do
       expect(response_json['message'])
       .to eq 'reQuest completed!'
+    end
+
+    it 'rewards the helper with the karma points from the request' do
+      expect(user2.karma_points).to eq @points_before + request.reward
     end
   end
 


### PR DESCRIPTION
[PT](https://www.pivotaltracker.com/story/show/173333476)
- Points are now transferred to the helper on quest completion
- Points are still taken from the requester on request creation and locked in the request.
  The acceptance criteria says to move the check, but then more acceptance criteria are needed for it to make sense, so I did not move it yet.

[PT BUG](https://www.pivotaltracker.com/story/show/173433769)
It was possible to create negative reward requests. This is no longer possible