### PR TITLE
Requester can reply to helper & Helper can reply to requester

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,11 @@ The format is, in *descending* order by id, meaning newest first:
       {
         "id": 1,
         "email": "person1@example.com",
-        "message": "hi I'd like to help you",
         "status": "pending"
       },
       {
         "id": 2,
         "email": "person2@example.com"
-        "message": "hey, saw you needed help, I can",
         "status": "declined"
       }
     ]
@@ -207,7 +205,7 @@ Auth headers are required. Offer :id in endpoint.
     helper_id: 2,
     request_id: 3,
     status: "pending", (OR "declined", OR "accepted",)
-    message: "Your offer is pending" (OR "Your offer has been accepted" OR "Your offer has been declined")
+    status_message: "Your offer is pending" (OR "Your offer has been accepted" OR "Your offer has been declined")
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -248,3 +248,14 @@ Headers as parameter needed for getting the quest list of a specific user
 ```
 {"message": "There are no quests to show"}
 ```
+
+### /messages
+#### POST /messages
+
+Takes auth headers and params: :offer_id, :content="String".
+Responds with 201 header, no body if ok.
+If no headers you get devise auth error.
+If you are not requester or helper, you get 422 { message: "You are not authorized" }
+If :content is missing you get 422 { message: "Content can't be blank" }
+If :offer_id is not excluded you get 422 { message: "Some error message" }
+

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,13 @@
+class Api::MessagesController < ApplicationController
+  before_action :authenticate_user!
+
+  def create
+    message = Offer.find(params[:offer_id]).conversation
+         .messages.create(content: params[:content], sender: current_user)
+    if message.persisted?
+      render status: :created
+    else
+      render_error_message(message.errors)
+    end
+  end
+end

--- a/app/controllers/api/my_request/requests_controller.rb
+++ b/app/controllers/api/my_request/requests_controller.rb
@@ -4,8 +4,6 @@ class Api::MyRequest::RequestsController < ApplicationController
   before_action :authenticate_user!, only: %i[index show create update]
   before_action :get_request, only: %i[update show]
   before_action :karma?, only: [:create]
-  rescue_from ArgumentError, with: :render_error_message
-  rescue_from StandardError, with: :render_error_message
 
   def index
     requests = Request.where(requester: current_user).order('id DESC')
@@ -50,16 +48,6 @@ class Api::MyRequest::RequestsController < ApplicationController
     unless current_user.karma_points - create_params[:reward].to_i >= 0
       render json: { message: 'You dont have enough karma points' }, status: 422
     end
-  end
-
-  def render_error_message(errors)
-    error_message = if !errors.class.method_defined?(:full_messages)
-                      errors.message
-                    else
-                      errors.full_messages.to_sentence
-                    end
-
-    render json: { message: error_message }, status: 422
   end
 
   def show_params

--- a/app/controllers/api/offers_controller.rb
+++ b/app/controllers/api/offers_controller.rb
@@ -7,6 +7,7 @@ class Api::OffersController < ApplicationController
   def create
     offer = current_user.offers.create(offer_parameters)
     if offer.persisted?
+      offer.append_message(params[:message]) if params[:message]
       render json: { message: 'Your offer has been sent!' }
     else
       render json: { message: offer.errors.full_messages.join('. ') }, status: 422

--- a/app/controllers/api/offers_controller.rb
+++ b/app/controllers/api/offers_controller.rb
@@ -52,6 +52,6 @@ class Api::OffersController < ApplicationController
   end
 
   def offer_parameters
-    params.permit(:message, :request_id)
+    params.permit(:request_id)
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,15 @@
 
 class ApplicationController < ActionController::API
   include DeviseTokenAuth::Concerns::SetUserByToken
+  rescue_from StandardError, with: :render_error_message
+
+  def render_error_message(errors)
+    error_message = if !errors.class.method_defined?(:full_messages)
+                      errors.message
+                    else
+                      errors.full_messages.to_sentence
+                    end
+
+    render json: { message: error_message }, status: 422
+  end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,2 +1,0 @@
-class MessagesController < ApplicationController
-end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,0 +1,2 @@
+class MessagesController < ApplicationController
+end

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -1,3 +1,4 @@
 class Conversation < ApplicationRecord
   belongs_to :offer
+  has_many :messages
 end

--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -1,0 +1,3 @@
+class Conversation < ApplicationRecord
+  belongs_to :offer
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,4 @@
+class Message < ApplicationRecord
+  belongs_to :conversation
+  belongs_to :sender, class_name: 'User'
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -8,6 +8,6 @@ class Message < ApplicationRecord
 
   def validate_user_is_authorized
     is_valid_user = sender == conversation.offer.helper || sender == conversation.offer.request.requester
-    raise StandardError, "You are not authorized to do this!" unless is_valid_user
+    raise StandardError, 'You are not authorized to do this!' unless is_valid_user
   end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,4 +1,5 @@
 class Message < ApplicationRecord
   belongs_to :conversation
   belongs_to :sender, class_name: 'User'
+  validates_presence_of :content
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -2,4 +2,12 @@ class Message < ApplicationRecord
   belongs_to :conversation
   belongs_to :sender, class_name: 'User'
   validates_presence_of :content
+  before_create :validate_user_is_authorized
+
+  private
+
+  def validate_user_is_authorized
+    is_valid_user = sender == conversation.offer.helper || sender == conversation.offer.request.requester
+    raise StandardError, "You are not authorized to do this!" unless is_valid_user
+  end
 end

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -5,9 +5,11 @@ class Offer < ApplicationRecord
   validates_presence_of :status
   belongs_to :request
   belongs_to :helper, class_name: 'User'
+  has_one :conversation
   validates_uniqueness_of :helper_id, scope: :request_id, message: 'is already registered with this request'
   enum status: %i[pending accepted declined]
   before_update :update_request_status
+  after_create :attach_conversation
 
   private
 
@@ -21,5 +23,9 @@ class Offer < ApplicationRecord
     if accepted? && status_was == 'pending'
       request.update_when_offer_accepted(helper)
     end
+  end
+
+  def attach_conversation
+    Conversation.create(offer_id: id)
   end
 end

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -11,6 +11,10 @@ class Offer < ApplicationRecord
   before_update :update_request_status
   after_create :attach_conversation
 
+  def append_message(message)
+    conversation.messages.create(content: message, sender: helper)
+  end
+
   private
 
   def validate_offer_creator

--- a/app/serializers/message_serializer.rb
+++ b/app/serializers/message_serializer.rb
@@ -1,5 +1,0 @@
-class MessageSerializer < ActiveModel::Serializer
-  attributes :id, :content
-  has_one :conversation
-  has_one :user
-end

--- a/app/serializers/message_serializer.rb
+++ b/app/serializers/message_serializer.rb
@@ -1,0 +1,5 @@
+class MessageSerializer < ActiveModel::Serializer
+  attributes :id, :content
+  has_one :conversation
+  has_one :user
+end

--- a/app/serializers/my_request/request/show_serializer.rb
+++ b/app/serializers/my_request/request/show_serializer.rb
@@ -7,7 +7,7 @@ class MyRequest::Request::ShowSerializer < ActiveModel::Serializer
     offers_response = []
     object.offers.each do |offer|
       helper = User.find(offer.helper_id)
-      offers_response << { id: offer.id, email: helper.email, message: offer.message, status: offer.status }
+      offers_response << { id: offer.id, email: helper.email, status: offer.status }
     end
 
     offers_response

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  resources :messages
   mount_devise_token_auth_for 'User', at: 'api/auth'
   namespace :api do
+    resources :messages, only: [:create]
     resources :offers, only: %i[create show update]
     resources :karma_points, only: [:index], constraints: { format: 'json' }
     resources :requests, only: %i[index], constraints: { format: 'json' }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  resources :messages
   mount_devise_token_auth_for 'User', at: 'api/auth'
   namespace :api do
     resources :offers, only: %i[create show update]

--- a/db/migrate/20200624121908_create_conversations.rb
+++ b/db/migrate/20200624121908_create_conversations.rb
@@ -1,0 +1,9 @@
+class CreateConversations < ActiveRecord::Migration[6.0]
+  def change
+    create_table :conversations do |t|
+      t.belongs_to :offer, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200624123333_create_messages.rb
+++ b/db/migrate/20200624123333_create_messages.rb
@@ -1,0 +1,11 @@
+class CreateMessages < ActiveRecord::Migration[6.0]
+  def change
+    create_table :messages do |t|
+      t.belongs_to :conversation, null: false, foreign_key: true
+      t.text :content, null: false
+      t.belongs_to :sender, null: false, foreign_key: { to_table: :users }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20200624151907_remove_message_from_offer.rb
+++ b/db/migrate/20200624151907_remove_message_from_offer.rb
@@ -1,0 +1,5 @@
+class RemoveMessageFromOffer < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :offers, :message
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,27 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_18_180607) do
+ActiveRecord::Schema.define(version: 2020_06_24_123333) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "conversations", force: :cascade do |t|
+    t.bigint "offer_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["offer_id"], name: "index_conversations_on_offer_id"
+  end
+
+  create_table "messages", force: :cascade do |t|
+    t.bigint "conversation_id", null: false
+    t.text "content"
+    t.bigint "sender_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["conversation_id"], name: "index_messages_on_conversation_id"
+    t.index ["sender_id"], name: "index_messages_on_sender_id"
+  end
 
   create_table "offers", force: :cascade do |t|
     t.string "message"
@@ -35,8 +52,10 @@ ActiveRecord::Schema.define(version: 2020_06_18_180607) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "reward"
     t.integer "status", default: 0
-    t.bigint "helper_id"
     t.integer "category", default: 0
+    t.bigint "helper_id"
+    t.float "long"
+    t.float "lat"
     t.index ["helper_id"], name: "index_requests_on_helper_id"
     t.index ["requester_id"], name: "index_requests_on_requester_id"
   end
@@ -70,6 +89,9 @@ ActiveRecord::Schema.define(version: 2020_06_18_180607) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
+  add_foreign_key "conversations", "offers"
+  add_foreign_key "messages", "conversations"
+  add_foreign_key "messages", "users", column: "sender_id"
   add_foreign_key "offers", "users", column: "helper_id"
   add_foreign_key "requests", "users", column: "helper_id"
   add_foreign_key "requests", "users", column: "requester_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_24_123333) do
+ActiveRecord::Schema.define(version: 2020_06_24_151907) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -33,7 +33,6 @@ ActiveRecord::Schema.define(version: 2020_06_24_123333) do
   end
 
   create_table "offers", force: :cascade do |t|
-    t.string "message"
     t.bigint "helper_id"
     t.bigint "request_id"
     t.datetime "created_at", precision: 6, null: false

--- a/spec/factories/conversations.rb
+++ b/spec/factories/conversations.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :conversation do
+    offer
+  end
+end

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :message do
+    conversation
+    content { "MyText" }
+    user
+  end
+end

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :message do
     conversation
     content { "MyText" }
-    user
+    association :sender, factory: :user
   end
 end

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :message do
     conversation
     content { "MyText" }
-    association :sender, factory: :user
+    sender { conversation.offer.helper }
   end
 end

--- a/spec/factories/offers.rb
+++ b/spec/factories/offers.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :offer do
-    message { 'I want  to help' }
     association :helper, factory: :user
     association :request
     status { 'pending' }

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe Conversation, type: :model do
+  describe 'relations' do
+    it { is_expected.to belong_to :offer }
+    it { is_expected.to have_many :messages }
+  end
+
+  describe 'factory' do
+    it 'should be valid' do
+      expect(create(:conversation)).to be_valid
+    end
+  end
+end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe Message, type: :model do
+  describe 'database table' do
+    it { is_expected.to have_db_column :content }
+    it { is_expected.to have_db_column :sender_id }
+    it { is_expected.to have_db_column :conversation }
+  end
+
+  describe 'validations' do
+    it { is_expected.to validate_presence_of :content}
+  end
+
+  describe 'relations' do
+    it { is_expected.to belong_to :conversation }
+    it { is_expected.to belong_to :sender }
+  end
+
+  describe 'factory' do
+    it 'should be valid' do
+      expect(create(:message)).to be_valid
+    end
+  end
+end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe Message, type: :model do
   describe 'database table' do
     it { is_expected.to have_db_column :content }
     it { is_expected.to have_db_column :sender_id }
-    it { is_expected.to have_db_column :conversation }
+    it { is_expected.to have_db_column :conversation_id }
   end
 
   describe 'validations' do
-    it { is_expected.to validate_presence_of :content}
+    it { is_expected.to validate_presence_of :content }
   end
 
   describe 'relations' do

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Offer, type: :model do
   describe 'database table' do
-    it { is_expected.to have_db_column :message }
+    it { is_expected.not_to have_db_column :message }
     it { is_expected.to have_db_column :request_id }
     it { is_expected.to have_db_column :helper_id }
     it { is_expected.to have_db_column :status }

--- a/spec/models/offer_spec.rb
+++ b/spec/models/offer_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Offer, type: :model do
   describe 'relations' do
     it { is_expected.to belong_to :helper }
     it { is_expected.to belong_to :request }
+    it { is_expected.to have_one :conversation }
   end
 
   describe 'factory' do

--- a/spec/requests/api/conversions/users_can_send_messages_spec.rb
+++ b/spec/requests/api/conversions/users_can_send_messages_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'POST /message users can post messages' do
   let(:request) { create(:request, requester: requester) }
   let(:offer) { create(:offer, request: request, helper: helper) }
 
-  let(:message) { create(:message, conversation: offer.conversation, sender: helper) }
+  let!(:message) { create(:message, conversation: offer.conversation, sender: helper) }
 
   describe 'successfully as the requester' do
     before do
@@ -22,7 +22,7 @@ RSpec.describe 'POST /message users can post messages' do
     end
 
     it 'gives a success status' do
-      expect(request).to have_http_status 201
+      expect(response).to have_http_status 201
     end
 
     it 'creates a message based on the params' do
@@ -37,7 +37,12 @@ RSpec.describe 'POST /message users can post messages' do
     end
 
     it 'gives a success status' do
-      expect(request).to have_http_status 201
+      expect(response).to have_http_status 201
+    end
+
+    it 'creates a message based on the params' do
+      offer.reload
+      expect(offer.conversation.messages.last['content']).to eq "message content"
     end
   end
 
@@ -46,23 +51,56 @@ RSpec.describe 'POST /message users can post messages' do
       before do
         post '/api/messages', headers: helper_headers, params: { offer_id: offer.id }
       end
+
+      it 'gives an error status' do
+        expect(response).to have_http_status 422
+      end
+
+      it 'gives an error message' do
+        expect(response_json['message']).to eq "Content can't be blank"
+      end
     end
 
     describe 'without offer_id' do
       before do
-        post '/api/messages', headers: helper_headers, params: { content: "message content" }
+        post '/api/messages', headers: helper_headers, params: { content: 'message content' }
+      end
+
+      it 'gives an error status' do
+        expect(response).to have_http_status 422
+      end
+
+      it 'gives an error message' do
+        expect(response_json['message']).to eq "Couldn't find Offer without an ID"
       end
     end
 
     describe 'unauthorized' do
       before do
-        post '/api/messages', headers: third_user_headers, params: { offer_id: offer.id, content: "message content" }
+        post '/api/messages', headers: third_user_headers, params: { offer_id: offer.id, content: 'message content' }
+      end
+
+      it 'gives an error status' do
+        expect(response).to have_http_status 422
+      end
+
+      it 'gives an error message' do
+        expect(response_json['message']).to eq 'You are not authorized to do this!'
       end
     end
 
     describe 'unauthenticated' do
       before do
-        post '/api/messages', params: { offer_id: offer.id, content: "message content" }
+        post '/api/messages', params: { offer_id: offer.id, content: 'message content' }
+      end
+
+
+      it 'gives an error status' do
+        expect(response).to have_http_status 401
+      end
+
+      it 'gives an error message' do
+        expect(response_json['errors'].first).to eq 'You need to sign in or sign up before continuing.'
       end
     end
   end

--- a/spec/requests/api/conversions/users_can_send_messages_spec.rb
+++ b/spec/requests/api/conversions/users_can_send_messages_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe 'POST /message users can post messages' do
+  let(:requester) { create(:user, email: 'requester@mail.com') }
+  let(:req_creds) { requester.create_new_auth_token }
+  let(:req_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(req_creds) }
+
+  let(:helper) { create(:user) }
+  let(:helper_credentials) { helper.create_new_auth_token }
+  let(:helper_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(helper_credentials) }
+
+  let(:third_user) { create(:user) }
+  let(:third_user_credentials) { third_user.create_new_auth_token }
+  let(:third_user_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(third_user_credentials) }
+  
+  let(:request) { create(:request, requester: requester) }
+  let(:offer) { create(:offer, request: request, helper: helper) }
+
+  let(:message) { create(:message, conversation: offer.conversation, sender) }
+
+
+end

--- a/spec/requests/api/offers/create_spec.rb
+++ b/spec/requests/api/offers/create_spec.rb
@@ -37,8 +37,12 @@ RSpec.describe 'POST /offers, user can offer to help' do
         expect(@offer.request).to eq request
       end
 
-      it 'the message' do
-        expect(@offer.message).to eq 'Hi, I can help!'
+      it 'the message as the first message of the conversation' do
+        expect(@offer.conversation.messages.first.content).to eq 'Hi, I can help!'
+      end
+
+      it 'the helper as the sender of the first message of the conversation' do
+        expect(@offer.conversation.messages.first.sender).to eq helper
       end
     end
   end

--- a/spec/requests/api/offers/show_spec.rb
+++ b/spec/requests/api/offers/show_spec.rb
@@ -15,26 +15,24 @@ RSpec.describe 'GET /api/offers/:id', type: :request do
   describe 'successfully with valid params and headers' do
     describe 'for pending request' do
       let(:offer) do
-        create(:offer,  status: 'pending', message: 'I can help you', helper_id: helper.id, request_id: request.id)
+        off = create(:offer,  status: 'pending', helper_id: helper.id, request_id: request.id)
+        off.append_message('I can help you')
+        off
       end
 
       before do
         get "/api/offers/#{offer.id}",
             headers: helper_headers
       end
-  
+
       it 'has 200 response' do
         expect(response).to have_http_status 200
       end
-  
-      it 'responds offer message' do
-        expect(response_json['offer']['message']).to eq 'I can help you'
-      end
-  
+
       it 'responds offer status' do
         expect(response_json['offer']['status']).to eq 'pending'
       end
-  
+
       it 'responds with offer status message' do
         expect(response_json['status_message']).to eq 'Your offer is pending'
       end
@@ -42,7 +40,9 @@ RSpec.describe 'GET /api/offers/:id', type: :request do
 
     describe 'for accepted request' do
       let(:offer) do
-        create(:offer, status: 'accepted', message: 'I can help you', helper_id: helper.id, request_id: request.id)
+        off = create(:offer, status: 'accepted', helper_id: helper.id, request_id: request.id)
+        off.append_message('I can help you')
+        off
       end
 
       before do
@@ -53,7 +53,7 @@ RSpec.describe 'GET /api/offers/:id', type: :request do
       it 'responds offer status' do
         expect(response_json['offer']['status']).to eq 'accepted'
       end
-  
+
       it 'responds with offer status message' do
         expect(response_json['status_message']).to eq 'Your offer has been accepted'
       end
@@ -61,7 +61,9 @@ RSpec.describe 'GET /api/offers/:id', type: :request do
 
     describe 'for declined request' do
       let(:offer) do
-        create(:offer, status: 'declined', message: 'I can help you', helper_id: helper.id, request_id: request.id)
+        off = create(:offer, status: 'declined', helper_id: helper.id, request_id: request.id)
+        off.append_message('I can help you')
+        off
       end
 
       before do
@@ -72,7 +74,7 @@ RSpec.describe 'GET /api/offers/:id', type: :request do
       it 'responds offer status' do
         expect(response_json['offer']['status']).to eq 'declined'
       end
-  
+
       it 'responds with offer status message' do
         expect(response_json['status_message']).to eq 'Your offer has been declined'
       end
@@ -88,7 +90,7 @@ RSpec.describe 'GET /api/offers/:id', type: :request do
       it 'has 401 response' do
         expect(response).to have_http_status 401
       end
-  
+
       it 'responds error message' do
         expect(response_json['errors'].first).to eq 'You need to sign in or sign up before continuing.'
       end
@@ -96,14 +98,14 @@ RSpec.describe 'GET /api/offers/:id', type: :request do
 
     describe 'offer cant be found' do
       before do
-        get "/api/offers/1000",
+        get '/api/offers/1000',
             headers: helper_headers
       end
 
       it 'has 500 response' do
         expect(response).to have_http_status 500
       end
-  
+
       it 'responds error message' do
         expect(response_json['error_message']).to eq "Couldn't find Offer with 'id'=1000 [WHERE \"offers\".\"helper_id\" = $1]"
       end
@@ -120,7 +122,7 @@ RSpec.describe 'GET /api/offers/:id', type: :request do
       it 'has 500 response' do
         expect(response).to have_http_status 500
       end
-  
+
       it 'responds error message' do
         expect(response_json['error_message']).to eq "Couldn't find Offer with 'id'=#{another_offer.id} [WHERE \"offers\".\"helper_id\" = $1]"
       end

--- a/spec/serializers/my_request/requests/show_serializer_spec.rb
+++ b/spec/serializers/my_request/requests/show_serializer_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe MyRequest::Request::ShowSerializer, type: :serializer do
   let(:user) { create(:user) }
   let(:request) { create(:request) }
   let!(:offer) { create(:offer, request: request) }
-  let!(:message) { offer.conversation.messages.create(content: 'Hello', sender: user) }
+  let!(:message) { offer.append_message('Hi, I can help') }
   let(:serialization) do
     ActiveModelSerializers::SerializableResource.new(
       Request.last,
@@ -30,6 +30,10 @@ RSpec.describe MyRequest::Request::ShowSerializer, type: :serializer do
     expect(subject['request']['offers'].first.keys).to match expected_keys
   end
 
+  it 'conversation has a specific structure' do
+    expect(subject[''])
+  end
+
   it 'has a specific structure' do
     expect(subject).to match(
       'request' => {
@@ -41,11 +45,7 @@ RSpec.describe MyRequest::Request::ShowSerializer, type: :serializer do
         'offers' => a_collection_including({
           'id' => an_instance_of(Integer),
           'email' => a_string_including('@'),
-          'status' => an_instance_of(String),
-          'conversation' => a_collection_including({
-            "content": an_instance_of(String),
-            "sender": an_instance_of(Integer)
-          })
+          'status' => an_instance_of(String)
         })
       }
     )

--- a/spec/serializers/my_request/requests/show_serializer_spec.rb
+++ b/spec/serializers/my_request/requests/show_serializer_spec.rb
@@ -3,7 +3,8 @@
 RSpec.describe MyRequest::Request::ShowSerializer, type: :serializer do
   let(:user) { create(:user) }
   let(:request) { create(:request) }
-  let!(:offer) { create(:offer, request: request)}
+  let!(:offer) { create(:offer, request: request) }
+  let!(:message) { offer.conversation.messages.create(content: 'Hello', sender: user) }
   let(:serialization) do
     ActiveModelSerializers::SerializableResource.new(
       Request.last,
@@ -16,32 +17,35 @@ RSpec.describe MyRequest::Request::ShowSerializer, type: :serializer do
   subject { JSON.parse(serialization.to_json) }
 
   it 'wraps content in key reflecting model name' do
-    expect(subject.keys).to match ["request"]
+    expect(subject.keys).to match ['request']
   end
 
   it 'contains only id, title, description, reward, status and offers' do
     expected_keys = %w[id title description reward status offers]
-    expect(subject["request"].keys).to match expected_keys
+    expect(subject['request'].keys).to match expected_keys
   end
 
   it 'offer contains only id, email, message and status' do
-    expected_keys = %w[id email message status]
-    expect(subject["request"]["offers"].first.keys).to match expected_keys
+    expected_keys = %w[id email status]
+    expect(subject['request']['offers'].first.keys).to match expected_keys
   end
 
   it 'has a specific structure' do
     expect(subject).to match(
-      "request" => {
-        "id" => an_instance_of(Integer),
-        "title" => an_instance_of(String),
-        "description" => an_instance_of(String),
-        "reward" => an_instance_of(Integer),
-        "status" => an_instance_of(String),
-        "offers" => a_collection_including({
-          "id" => an_instance_of(Integer),
-          "email" => a_string_including("@"),
-          "message" => an_instance_of(String),
-          "status" => an_instance_of(String)
+      'request' => {
+        'id' => an_instance_of(Integer),
+        'title' => an_instance_of(String),
+        'description' => an_instance_of(String),
+        'reward' => an_instance_of(Integer),
+        'status' => an_instance_of(String),
+        'offers' => a_collection_including({
+          'id' => an_instance_of(Integer),
+          'email' => a_string_including('@'),
+          'status' => an_instance_of(String),
+          'conversation' => a_collection_including({
+            "content": an_instance_of(String),
+            "sender": an_instance_of(Integer)
+          })
         })
       }
     )


### PR DESCRIPTION
[PT feature 1](https://www.pivotaltracker.com/story/show/173450056)
[PT feature 2](https://www.pivotaltracker.com/story/show/173450034)
This adds a conversation model, message model, messages controller with :create action
offers has_one conversation
message has keys content:text, conversation_id:conversation and sender:user.
The create action takes the :id of the OFFER not the conversation. This makes it so that frontend never needs to know the id of the conversation.
Only the helper and the requester are allowed to post messages to a conversation.
An empty conversation object is created on creation of an offer.
A new offer with the message param will still create a message but instead put it as a message in the conversation.