### PR TITLE
API serves conversation identifying the sender

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,20 @@ The format is, in *descending* order by id, meaning newest first:
         "id": 1,
         "email": "person1@example.com",
         "status": "pending"
+        "conversation: {
+          "messages": [
+            {
+              "content": "asd",
+              "me": true
+            }
+          ]
+        }
       },
       {
         "id": 2,
         "email": "person2@example.com"
         "status": "declined"
+        "conversation": {...}
       }
     ]
   }

--- a/app/serializers/my_request/request/show_serializer.rb
+++ b/app/serializers/my_request/request/show_serializer.rb
@@ -7,7 +7,17 @@ class MyRequest::Request::ShowSerializer < ActiveModel::Serializer
     offers_response = []
     object.offers.each do |offer|
       helper = User.find(offer.helper_id)
-      offers_response << { id: offer.id, email: helper.email, status: offer.status }
+      offers_response << {
+        id: offer.id,
+        email: helper.email,
+        status: offer.status,
+        conversation: {
+          messages:
+          offer.conversation.messages.map do |message|
+            { content: message.content, me: message.sender == current_user }
+          end
+        }
+      }
     end
 
     offers_response

--- a/spec/serializers/my_request/requests/show_serializer_spec.rb
+++ b/spec/serializers/my_request/requests/show_serializer_spec.rb
@@ -26,31 +26,31 @@ RSpec.describe MyRequest::Request::ShowSerializer, type: :serializer do
   end
 
   it 'offer contains only id, email, message and status' do
-    expected_keys = %w[id email status]
+    expected_keys = %w[id email status conversation]
     expect(subject['request']['offers'].first.keys).to match expected_keys
   end
 
-  it 'conversation has a specific structure' do
-    expected_keys = %w[me content]
-    expect(subject['request']['offers'].first['conversation'].keys).to match expected_keys
+  it 'conversation has messages with keys content, me' do
+    expected_keys = %w[content me]
+    expect(subject['request']['offers'].first['conversation']['messages'].first.keys).to match expected_keys
   end
 
   it 'has a specific structure' do
     expect(subject).to match(
       'request' => {
-        'id' => an_instance_of(Integer),
-        'title' => an_instance_of(String),
         'description' => an_instance_of(String),
+        'id' => an_instance_of(Integer),
         'reward' => an_instance_of(Integer),
         'status' => an_instance_of(String),
+        'title' => an_instance_of(String),
         'offers' => a_collection_including({
-          'id' => an_instance_of(Integer),
           'email' => a_string_including('@'),
+          'id' => an_instance_of(Integer),
           'status' => an_instance_of(String),
           'conversation' => {
             'messages' => a_collection_including({
               'content' => an_instance_of(String),
-              'me' => an_instance_of(TrueClass) || an_instance_of(FalseClass)
+              'me' => an_instance_of(FalseClass)
             })
           }
         })

--- a/spec/serializers/my_request/requests/show_serializer_spec.rb
+++ b/spec/serializers/my_request/requests/show_serializer_spec.rb
@@ -31,7 +31,8 @@ RSpec.describe MyRequest::Request::ShowSerializer, type: :serializer do
   end
 
   it 'conversation has a specific structure' do
-    expect(subject[''])
+    expected_keys = %w[me content]
+    expect(subject['request']['offers'].first['conversation'].keys).to match expected_keys
   end
 
   it 'has a specific structure' do
@@ -45,7 +46,13 @@ RSpec.describe MyRequest::Request::ShowSerializer, type: :serializer do
         'offers' => a_collection_including({
           'id' => an_instance_of(Integer),
           'email' => a_string_including('@'),
-          'status' => an_instance_of(String)
+          'status' => an_instance_of(String),
+          'conversation' => {
+            'messages' => a_collection_including({
+              'content' => an_instance_of(String),
+              'me' => an_instance_of(TrueClass) || an_instance_of(FalseClass)
+            })
+          }
         })
       }
     )


### PR DESCRIPTION
[PT Feature](https://www.pivotaltracker.com/story/show/173487313)
Adds conversation to the request/show
the structure is
request: {
  ...
  offers: [
    {
      ...
      conversation: { messages: [ {content: "", me: true }, {...} ]}
    }
  ]
}
