### PR TITLE
Distance to request location is shown in browsing list

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'bootsnap', '>= 1.4.2', require: false
 gem 'rack-cors', require: 'rack/cors'
 gem 'devise_token_auth'
 gem 'active_model_serializers'
+gem 'haversine'
 
 group :development, :test do
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,7 @@ GEM
     ffi (1.13.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    haversine (0.3.2)
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
     json (2.3.0)
@@ -234,6 +235,7 @@ DEPENDENCIES
   devise_token_auth
   factory_bot_rails
   faker
+  haversine
   listen (~> 3.2)
   pg (>= 0.18, < 2.0)
   pry-byebug

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ All endpoints are prefixed with `/api`
 
 The get request will return all the *pending* requests in the database.
 Offerable is null if auth headers are not included, and false if the request is created by, or has an offer from, current user. True otherwise.
+If params: { coordinates: { lat: 1.4, long: 4.2 } } are included and geovalid, the distance from request coordinates is served as a float in km, otherwise distance: nil.
 The format is, in *descending* order by id, meaning newest first:
 
 ```
@@ -21,8 +22,9 @@ The format is, in *descending* order by id, meaning newest first:
       description: "Lots of text",
       requester: "requester@mail.com",
       category: "home",
-      reward: 100
-      offerable: true
+      reward: 100,
+      offerable: true,
+      distance: 1.2
     },
     {
       id: 2,
@@ -32,6 +34,7 @@ The format is, in *descending* order by id, meaning newest first:
       category: "it",
       reward: 120
       offerable: false
+      distance: 3.1
     }
   ]
 }

--- a/app/controllers/api/requests_controller.rb
+++ b/app/controllers/api/requests_controller.rb
@@ -10,12 +10,28 @@ class Api::RequestsController < ApplicationController
                  Request.where(*request_params, status: "pending").order('id DESC')
                end
 
-    render json: requests, each_serializer: Request::IndexSerializer
+    render json: requests, each_serializer: Request::IndexSerializer, coordinates: check_coordinates
   end
 
   private
 
   def request_params
-    params.permit(:category)
+    { category: params[:category] }
+  end
+
+  def check_coordinates
+    ok = params[:coordinates] &&
+         params[:coordinates][:lat] &&
+         params[:coordinates][:long]
+    return nil unless ok
+    lat = params[:coordinates][:lat].to_f
+    long = params[:coordinates][:long].to_f
+    ok = lat >= -90 &&
+         lat <= 90 &&
+         long >= -180 &&
+         long <= 180
+    return nil unless ok
+
+    [lat, long]
   end
 end

--- a/app/controllers/api/requests_controller.rb
+++ b/app/controllers/api/requests_controller.rb
@@ -16,7 +16,7 @@ class Api::RequestsController < ApplicationController
   private
 
   def request_params
-    { category: params[:category] }
+    params.permit(:category)
   end
 
   def check_coordinates

--- a/app/serializers/request/index_serializer.rb
+++ b/app/serializers/request/index_serializer.rb
@@ -18,6 +18,6 @@ class Request::IndexSerializer < ActiveModel::Serializer
   def distance
     return nil if instance_options[:coordinates].nil?
 
-    Haversine.distance(instance_options[:coordinates], [object.lat, object.long]).to_km
+    Haversine.distance(instance_options[:coordinates], [object.lat, object.long]).to_km.round(1)
   end
 end

--- a/app/serializers/request/index_serializer.rb
+++ b/app/serializers/request/index_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Request::IndexSerializer < ActiveModel::Serializer
-  attributes :id, :title, :description, :requester, :offerable, :reward, :category
+  attributes :id, :title, :description, :requester, :offerable, :reward, :category, :distance
 
   def requester
     object.requester.uid
@@ -13,5 +13,11 @@ class Request::IndexSerializer < ActiveModel::Serializer
 
     current_user_offers = object.offers.find_all { |offer| offer.helper_id == current_user.id }
     current_user_offers.empty? ? true : false
+  end
+
+  def distance
+    return nil if instance_options[:coordinates].nil?
+
+    Haversine.distance(instance_options[:coordinates], [object.lat, object.long]).to_km
   end
 end

--- a/spec/requests/api/requests/index_location.rb
+++ b/spec/requests/api/requests/index_location.rb
@@ -29,6 +29,17 @@ RSpec.describe 'GET /api/requests, distance to request is displayed' do
     end
   end
 
+  describe 'with location parameters and category' do
+    before do
+      get '/api/requests',
+      params: { coordinates: { long: 14.48, lat: 61.0 }, category: 'education' }
+    end
+
+    it 'gives the requests it should' do
+      expect(response_json['requests'].length).to eq 3
+    end
+  end
+
   describe 'without location parameters' do
     before do
       get '/api/requests'

--- a/spec/requests/api/requests/index_location.rb
+++ b/spec/requests/api/requests/index_location.rb
@@ -1,6 +1,6 @@
 RSpec.describe 'GET /api/requests, distance to request is displayed' do
-  let!(:falun) { create(:request, long: 15.6, lat: 60.6 ) }
-  let!(:leksand) { create(:request, long: 15.0, lat: 60.73 ) }
+  let!(:falun) { create(:request, long: 15.596, lat: 60.604 ) }
+  let!(:leksand) { create(:request, long: 15.0, lat: 60.732 ) }
   let!(:mora) { create(:request, long: 14.48, lat: 61.0 ) }
 
   describe 'with location parameters, requester in mora' do
@@ -11,21 +11,21 @@ RSpec.describe 'GET /api/requests, distance to request is displayed' do
 
     it 'calculates the distance correctly' do
       expect(response_json['requests'][0]['distance']).to be_within(0.1).of(0)
-      expect(response_json['requests'][1]['distance']).to be_within(0.1).of(39.5)
-      expect(response_json['requests'][2]['distance']).to be_within(0.1).of(74.2)
+      expect(response_json['requests'][1]['distance']).to be_within(2).of(39.8)
+      expect(response_json['requests'][2]['distance']).to be_within(3).of(74.2)
     end
   end
 
   describe 'with location parameters, requester in gävle' do
     before do
       get '/api/requests',
-      params: { coordinates: { long: 14.48, lat: 61.0 }}
+      params: { coordinates: { long: 17.141, lat: 60.675 }}
     end
 
     it 'calculates the distance correctly' do
-      expect(response_json['requests'][0]['distance']).to be_within(0.2).of(145.75)
-      expect(response_json['requests'][1]['distance']).to be_within(0.2).of(116.8)
-      expect(response_json['requests'][2]['distance']).to be_within(0.2).of(82.75)
+      expect(response_json['requests'][0]['distance']).to be_within(4).of(145.75)
+      expect(response_json['requests'][1]['distance']).to be_within(3).of(116.8)
+      expect(response_json['requests'][2]['distance']).to be_within(2).of(82.75)
     end
   end
 

--- a/spec/requests/api/requests/index_location.rb
+++ b/spec/requests/api/requests/index_location.rb
@@ -1,0 +1,63 @@
+RSpec.describe 'GET /api/requests, distance to request is displayed' do
+  let!(:falun) { create(:request, long: 15.6, lat: 60.6 ) }
+  let!(:leksand) { create(:request, long: 15.0, lat: 60.73 ) }
+  let!(:mora) { create(:request, long: 14.48, lat: 61.0 ) }
+
+  describe 'with location parameters, requester in mora' do
+    before do
+      get '/api/requests',
+      params: { coordinates: { long: 14.48, lat: 61.0 }}
+    end
+
+    it 'calculates the distance correctly' do
+      expect(response_json['requests'][0]['distance']).to be_within(0.1).of(0)
+      expect(response_json['requests'][1]['distance']).to be_within(0.1).of(39.5)
+      expect(response_json['requests'][2]['distance']).to be_within(0.1).of(74.2)
+    end
+  end
+
+  describe 'with location parameters, requester in gävle' do
+    before do
+      get '/api/requests',
+      params: { coordinates: { long: 14.48, lat: 61.0 }}
+    end
+
+    it 'calculates the distance correctly' do
+      expect(response_json['requests'][0]['distance']).to be_within(0.2).of(145.75)
+      expect(response_json['requests'][1]['distance']).to be_within(0.2).of(116.8)
+      expect(response_json['requests'][2]['distance']).to be_within(0.2).of(82.75)
+    end
+  end
+
+  describe 'without location parameters' do
+    before do
+      get '/api/requests'
+    end
+
+    it 'returns distance as nil' do
+      expect(response_json['requests'][0]['distance']).to eq nil
+    end
+  end
+
+  describe 'with partial location parameters' do
+    before do
+      get '/api/requests',
+          params: { coordinates: { long: 33 } }
+    end
+
+    it 'returns distance as nil' do
+      expect(response_json['requests'][0]['distance']).to eq nil
+    end
+  end
+
+  describe 'with bad location parameters' do
+    before do
+      get '/api/requests',
+          params: { coordinates: { long: 190, lat: 99.0 }}
+    end
+
+    it 'returns distance as nil' do
+      expect(response_json['requests'][0]['distance']).to eq nil
+    end
+  end
+end

--- a/spec/serializers/requests/index_serializer_spec.rb
+++ b/spec/serializers/requests/index_serializer_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Request::IndexSerializer, type: :serializer do
   end
 
   it 'contains only id, title, description, requester, offerable reward and category' do
-    expected_keys = %w[id title description requester offerable reward category]
+    expected_keys = %w[id title description requester offerable reward category distance]
     expect(subject["requests"].first.keys).to match expected_keys
   end
 
@@ -33,6 +33,7 @@ RSpec.describe Request::IndexSerializer, type: :serializer do
         "reward" => an_instance_of(Integer),
         "offerable" => (an_instance_of(TrueClass) || an_instance_of(FalseClass) || an_instance_of(NilClass)),
         "category" => an_instance_of(String),
+        "distance" => an_instance_of(Float)
       })
     )
   end

--- a/spec/serializers/requests/index_serializer_spec.rb
+++ b/spec/serializers/requests/index_serializer_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe Request::IndexSerializer, type: :serializer do
     ActiveModelSerializers::SerializableResource.new(
       Request.all,
       each_serializer: described_class,
+      coordinates: [2.2, 5.5],
       scope: user,
       scope_name: :current_user
     )


### PR DESCRIPTION
[PT feature](https://www.pivotaltracker.com/story/show/173334484)
- adds haversine gem, make sure to bundle
- test distances is using google maps measure distance as reference, and I cannot verify those are more correct than the haversine gem, but ballpark is probably fine
- Adds key :distance to get /requests and is a float rounded to 1 decimal that represents the distance in km.
 