### PR TITLE
Refactors get quests, helper can see pending quests

### DIFF
--- a/app/controllers/api/my_request/quests_controller.rb
+++ b/app/controllers/api/my_request/quests_controller.rb
@@ -2,9 +2,13 @@
 
 class Api::MyRequest::QuestsController < ApplicationController
   before_action :authenticate_user!, only: %i[index]
+
   def index
-    quests = Request.where(helper: current_user).order('id DESC')
-    if quests == []
+    pending = current_user.offers.where(status: 'pending').map(&:request)
+    accepted_and_completed = current_user.offers.where(status: 'accepted').map(&:request)
+    quests = pending + accepted_and_completed
+
+    if quests.empty?
       render json: { message: 'There are no quests to show' }, status: 404
     else
       render json: quests, each_serializer: MyRequest::Quest::IndexSerializer, root: 'quests'


### PR DESCRIPTION
[PT Chore](https://www.pivotaltracker.com/story/show/173509357)
Refactors the get /quests to make sure we get all the requests where the user is or could become the helper.
Heavily updates the request spec to show that controller action is doing what it should.
Seems I may have done [PT feature](https://www.pivotaltracker.com/story/show/173508483) while I was at it.