### PR TITLE
API can serve the details of a single QUEST

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,36 @@ Headers as parameter needed for getting the quest list of a specific user
 {"message": "There are no quests to show"}
 ```
 
+#### GET /my_request/quest/:id
+Returns a request where the user has a non-declined offer.
+Errors are same as show request errors, except "This is not your Quest" one.
+Good response is 200:
+```
+{"quest": 
+  {
+    "id": 169,
+    "title": "I need  help with this",
+    "description": "This is what I need help with",
+    "email": "salvador@konopelskichristiansen.co",
+    "reward": 100,
+    "status": "pending",
+    "offer": {
+      "id": 151, 
+      "status": 
+      "pending", 
+      "conversation": {
+        "messages": [
+          {
+            "content": "Hi, I can help", 
+            "me": true
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
 ### /messages
 #### POST /messages
 

--- a/app/controllers/api/my_request/quests_controller.rb
+++ b/app/controllers/api/my_request/quests_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Api::MyRequest::QuestsController < ApplicationController
-  before_action :authenticate_user!, only: %i[index]
+  before_action :authenticate_user!, only: %i[index show]
   def index
     quests = Request.where(helper: current_user).order('id DESC')
     if quests == []
@@ -9,5 +9,11 @@ class Api::MyRequest::QuestsController < ApplicationController
     else
       render json: quests, each_serializer: MyRequest::Quest::IndexSerializer, root: 'quests'
     end
+  end
+
+  def show
+    quest = Request.find(params[:id])
+    quest.validate_quester(current_user)
+    render json: quest, serializer: MyRequest::Quest::ShowSerializer, root: 'quest'
   end
 end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -24,6 +24,15 @@ class Request < ApplicationRecord
     true
   end
 
+  def validate_quester(user)
+    valid = user
+            .offers.where.not(status: 'declined')
+            .map(&:request).include?(self)
+    raise StandardError, 'This is not your Quest' unless valid
+
+    true
+  end
+
   def update_when_offer_accepted(helper)
     update(status: 'active', helper: helper)
   end

--- a/app/serializers/my_request/quest/show_serializer.rb
+++ b/app/serializers/my_request/quest/show_serializer.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class MyRequest::Quest::ShowSerializer < ActiveModel::Serializer
+  attributes :id, :title, :description, :email, :reward, :status, :offer
+
+  def offer
+    offer = object.offers.find{|offer| offer.helper == current_user}
+    {
+      id: offer.id,
+      status: offer.status,
+      conversation: {
+        messages:
+        offer.conversation.messages.map do |message|
+          { content: message.content, me: message.sender == current_user }
+        end
+      }
+    }
+  end
+
+  def email
+    object.requester.email
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
     resources :requests, only: %i[index], constraints: { format: 'json' }
     namespace :my_request do
       resources :requests, only: %i[index show create update], constraints: { format: 'json' }
-      resources :quests, only: %i[index], constraints: { format: 'json' }
+      resources :quests, only: %i[index show], constraints: { format: 'json' }
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -24,7 +24,7 @@ ActiveRecord::Schema.define(version: 2020_06_24_151907) do
 
   create_table "messages", force: :cascade do |t|
     t.bigint "conversation_id", null: false
-    t.text "content"
+    t.text "content", null: false
     t.bigint "sender_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -51,10 +51,10 @@ ActiveRecord::Schema.define(version: 2020_06_24_151907) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "reward"
     t.integer "status", default: 0
-    t.integer "category", default: 0
     t.bigint "helper_id"
-    t.float "long"
-    t.float "lat"
+    t.integer "category", default: 0
+    t.float "long", null: false
+    t.float "lat", null: false
     t.index ["helper_id"], name: "index_requests_on_helper_id"
     t.index ["requester_id"], name: "index_requests_on_requester_id"
   end

--- a/spec/requests/api/my_request/quests/show_spec.rb
+++ b/spec/requests/api/my_request/quests/show_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'GET /api/my_request/quests/:id', type: :request do
 
   let(:not_my_quest) { create(:request) }
 
-  let!(:offer) { create(:offer, helper: helper, request: my_request) }
+  let!(:offer) { create(:offer, helper: helper, request: my_quest ) }
 
   let!(:message_1) { offer.conversation.messages.create(content: "message1", sender: requester) }
   let!(:message_2) { offer.conversation.messages.create(content: "message2", sender: helper) }
@@ -31,21 +31,21 @@ RSpec.describe 'GET /api/my_request/quests/:id', type: :request do
     end
 
     it 'the conversation has messages that show content' do
-      expect(response_json['quest']['offers'].first['conversation']['messages'].length).to eq 2
+      expect(response_json['quest']['offer']['conversation']['messages'].length).to eq 2
     end
 
     it 'and you can see if you are the sender of the message' do
-      expect(response_json['quest']['offers'].first['conversation']['messages'].first['me']).to eq false
+      expect(response_json['quest']['offer']['conversation']['messages'].first['me']).to eq false
     end
 
     it 'and you can see if you are not the sender of the message' do
-      expect(response_json['quest']['offers'].first['conversation']['messages'].last['me']).to eq true
+      expect(response_json['quest']['offer']['conversation']['messages'].last['me']).to eq true
     end
   end
 
   describe 'without valid credentials' do
     before do
-      get "/api/my_request/requests/#{my_request.id}"
+      get "/api/my_request/quests/#{my_quest.id}"
     end
 
     it 'has 401 status' do
@@ -59,7 +59,7 @@ RSpec.describe 'GET /api/my_request/quests/:id', type: :request do
 
   describe "targeting someone else's quest" do
     before do
-      get "/api/my_request/requests/#{not_my_quest.id}",
+      get "/api/my_request/quests/#{not_my_quest.id}",
           headers: helper_headers
     end
 
@@ -68,7 +68,7 @@ RSpec.describe 'GET /api/my_request/quests/:id', type: :request do
     end
 
     it 'responds with error message' do
-      expect(response_json['message']).to eq 'This is not your quest'
+      expect(response_json['message']).to eq 'This is not your Quest'
     end
   end
 end

--- a/spec/requests/api/my_request/quests/show_spec.rb
+++ b/spec/requests/api/my_request/quests/show_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+RSpec.describe 'GET /api/my_request/quests/:id', type: :request do
+  let(:helper) { create(:user) }
+  let(:helper_credentials) { helper.create_new_auth_token }
+  let(:helper_headers) { { HTTP_ACCEPT: 'application/json' }.merge!(helper_credentials) }
+
+  let(:requester) { create(:user) }
+
+  let(:my_quest) { create(:request, requester: requester, helper: helper) }
+
+  let(:not_my_quest) { create(:request) }
+
+  let!(:offer) { create(:offer, helper: helper, request: my_request) }
+
+  let!(:message_1) { offer.conversation.messages.create(content: "message1", sender: requester) }
+  let!(:message_2) { offer.conversation.messages.create(content: "message2", sender: helper) }
+
+  describe 'with valid credentials and params' do
+    before do
+      get "/api/my_request/quests/#{my_quest.id}",
+          headers: helper_headers
+    end
+
+    it 'has 200 response' do
+      expect(response).to have_http_status 200
+    end
+
+    it 'responds with correct quest' do
+      expect(response_json['quest']['id']).to eq my_quest.id
+    end
+
+    it 'the conversation has messages that show content' do
+      expect(response_json['quest']['offers'].first['conversation']['messages'].length).to eq 2
+    end
+
+    it 'and you can see if you are the sender of the message' do
+      expect(response_json['quest']['offers'].first['conversation']['messages'].first['me']).to eq false
+    end
+
+    it 'and you can see if you are not the sender of the message' do
+      expect(response_json['quest']['offers'].first['conversation']['messages'].last['me']).to eq true
+    end
+  end
+
+  describe 'without valid credentials' do
+    before do
+      get "/api/my_request/requests/#{my_request.id}"
+    end
+
+    it 'has 401 status' do
+      expect(response).to have_http_status 401
+    end
+
+    it 'responds with error message' do
+      expect(response_json['errors'][0]).to eq 'You need to sign in or sign up before continuing.'
+    end
+  end
+
+  describe "targeting someone else's quest" do
+    before do
+      get "/api/my_request/requests/#{not_my_quest.id}",
+          headers: helper_headers
+    end
+
+    it 'has 422 status' do
+      expect(response).to have_http_status 422
+    end
+
+    it 'responds with error message' do
+      expect(response_json['message']).to eq 'This is not your quest'
+    end
+  end
+end

--- a/spec/serializers/my_request/quests/show_serializer_spec.rb
+++ b/spec/serializers/my_request/quests/show_serializer_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+RSpec.describe MyRequest::Request::ShowSerializer, type: :serializer do
+  let(:user) { create(:user) }
+  let(:request) { create(:request) }
+  let!(:offer) { create(:offer, request: request) }
+  let!(:message) { offer.append_message('Hi, I can help') }
+  let(:serialization) do
+    ActiveModelSerializers::SerializableResource.new(
+      Request.last,
+      serializer: described_class,
+      scope: user,
+      scope_name: :current_user
+    )
+  end
+
+  subject { JSON.parse(serialization.to_json) }
+
+  it 'wraps content in key reflecting model name' do
+    expect(subject.keys).to match ['request']
+  end
+
+  it 'contains only id, title, description, reward, status and offers' do
+    expected_keys = %w[id title description reward status offer]
+    expect(subject['request'].keys).to match expected_keys
+  end
+
+  it 'offer contains only id, email, message and status' do
+    expected_keys = %w[id email status conversation]
+    expect(subject['request']['offer'].keys).to match expected_keys
+  end
+
+  it 'conversation has messages with keys content, me' do
+    expected_keys = %w[content me]
+    expect(subject['request']['offer']['conversation']['messages'].first.keys).to match expected_keys
+  end
+
+  it 'has a specific structure' do
+    expect(subject).to match(
+      'quest' => {
+        'id' => an_instance_of(Integer),
+        'title' => an_instance_of(String),
+        'description' => an_instance_of(String),
+        'reward' => an_instance_of(Integer),
+        'status' => an_instance_of(String),
+        'email' => a_string_including('@'),
+        'offer' => {
+          'id' => an_instance_of(Integer),
+          'status' => an_instance_of(String),
+          'conversation' => {
+            'messages' => a_collection_including({
+              'content' => an_instance_of(String),
+              'me' => an_instance_of(FalseClass)
+            })
+          }
+        }
+      }
+    )
+  end
+end

--- a/spec/serializers/my_request/quests/show_serializer_spec.rb
+++ b/spec/serializers/my_request/quests/show_serializer_spec.rb
@@ -1,38 +1,39 @@
 # frozen_string_literal: true
 
-RSpec.describe MyRequest::Request::ShowSerializer, type: :serializer do
+RSpec.describe MyRequest::Quest::ShowSerializer, type: :serializer do
   let(:user) { create(:user) }
   let(:request) { create(:request) }
-  let!(:offer) { create(:offer, request: request) }
+  let!(:offer) { create(:offer, request: request, helper: user) }
   let!(:message) { offer.append_message('Hi, I can help') }
   let(:serialization) do
     ActiveModelSerializers::SerializableResource.new(
       Request.last,
       serializer: described_class,
       scope: user,
-      scope_name: :current_user
+      scope_name: :current_user,
+      root: 'quest'
     )
   end
 
   subject { JSON.parse(serialization.to_json) }
 
   it 'wraps content in key reflecting model name' do
-    expect(subject.keys).to match ['request']
+    expect(subject.keys).to match ['quest']
   end
 
-  it 'contains only id, title, description, reward, status and offers' do
-    expected_keys = %w[id title description reward status offer]
-    expect(subject['request'].keys).to match expected_keys
+  it 'contains only id, title, description, email, reward, status and offers' do
+    expected_keys = %w[id title description email reward status offer]
+    expect(subject['quest'].keys).to match expected_keys
   end
 
-  it 'offer contains only id, email, message and status' do
-    expected_keys = %w[id email status conversation]
-    expect(subject['request']['offer'].keys).to match expected_keys
+  it 'offer contains only id, message and status' do
+    expected_keys = %w[id status conversation]
+    expect(subject['quest']['offer'].keys).to match expected_keys
   end
 
   it 'conversation has messages with keys content, me' do
     expected_keys = %w[content me]
-    expect(subject['request']['offer']['conversation']['messages'].first.keys).to match expected_keys
+    expect(subject['quest']['offer']['conversation']['messages'].first.keys).to match expected_keys
   end
 
   it 'has a specific structure' do
@@ -41,16 +42,16 @@ RSpec.describe MyRequest::Request::ShowSerializer, type: :serializer do
         'id' => an_instance_of(Integer),
         'title' => an_instance_of(String),
         'description' => an_instance_of(String),
+        'email' => a_string_including('@'),
         'reward' => an_instance_of(Integer),
         'status' => an_instance_of(String),
-        'email' => a_string_including('@'),
         'offer' => {
           'id' => an_instance_of(Integer),
           'status' => an_instance_of(String),
           'conversation' => {
             'messages' => a_collection_including({
               'content' => an_instance_of(String),
-              'me' => an_instance_of(FalseClass)
+              'me' => an_instance_of(TrueClass)
             })
           }
         }


### PR DESCRIPTION
[PT feature](https://www.pivotaltracker.com/story/show/173511499)
Adds GET /my_request/quest/:id
Requires auth headers.
See screen or README for serializer info
![Screen Shot 2020-06-25 at 17 36 00](https://user-images.githubusercontent.com/61978848/85750932-6c22d700-b70a-11ea-9553-907eba9e005c.png)

